### PR TITLE
Unified composable query system

### DIFF
--- a/.erb/configs/webpack.config.renderer.dev.ts
+++ b/.erb/configs/webpack.config.renderer.dev.ts
@@ -171,7 +171,14 @@ const configuration: webpack.Configuration = {
       debug: true,
     }),
 
-    new ReactRefreshWebpackPlugin(),
+    // Exclude Web Workers (*.worker.ts) from React Refresh. The refresh
+    // runtime references browser/HMR globals and gets pulled into the worker
+    // bundle, which then fails to `importScripts` the refresh runtime chunk in
+    // WorkerGlobalScope (Uncaught NetworkError on startup). Workers don't need
+    // HMR, so skip refresh injection for them.
+    new ReactRefreshWebpackPlugin({
+      exclude: [/node_modules/, /\.worker\.[jt]sx?$/],
+    }),
 
     new HtmlWebpackPlugin({
       filename: path.join('index.html'),

--- a/media-server/loki_api.go
+++ b/media-server/loki_api.go
@@ -262,6 +262,53 @@ func lokiMediaSearchHandler(deps *Dependencies) http.HandlerFunc {
 	}
 }
 
+func lokiMediaQueryHandler(deps *Dependencies) http.HandlerFunc {
+	type queryRequest struct {
+		Predicates []Predicate `json:"predicates"`
+		Mode       string      `json:"mode"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req queryRequest
+		if err := readJSON(r, &req); err != nil {
+			httpError(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		querySQL, params := BuildMediaQuery(req.Predicates, req.Mode)
+		rows, err := deps.DB.Query(querySQL, params...)
+		if err != nil {
+			httpError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer rows.Close()
+
+		items := []map[string]any{}
+		for rows.Next() {
+			var path string
+			var description sql.NullString
+			var elo sql.NullFloat64
+			var height, width sql.NullInt64
+			if err := rows.Scan(&path, &description, &elo, &height, &width); err != nil {
+				continue
+			}
+			item := map[string]any{"path": path}
+			if description.Valid {
+				item["description"] = description.String
+			}
+			if elo.Valid {
+				item["elo"] = elo.Float64
+			}
+			if height.Valid {
+				item["height"] = int(height.Int64)
+			}
+			if width.Valid {
+				item["width"] = int(width.Int64)
+			}
+			items = append(items, item)
+		}
+		writeJSON(w, items)
+	}
+}
+
 func lokiMediaMetadataHandler(deps *Dependencies) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req pathRequest

--- a/media-server/loki_api.go
+++ b/media-server/loki_api.go
@@ -1072,6 +1072,36 @@ func lokiTagCountHandler(deps *Dependencies) http.HandlerFunc {
 	}
 }
 
+func lokiPathSuggestHandler(deps *Dependencies) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		term := "%" + r.URL.Query().Get("term") + "%"
+		rows, err := deps.DB.Query(`SELECT DISTINCT path FROM media WHERE path LIKE ? LIMIT 50`, term)
+		if err != nil {
+			httpError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer rows.Close()
+		paths := []string{}
+		for rows.Next() {
+			var p string
+			if err := rows.Scan(&p); err != nil {
+				continue
+			}
+			paths = append(paths, p)
+		}
+		writeJSON(w, paths)
+	}
+}
+
+func lokiCategoryCountHandler(deps *Dependencies) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		category := r.URL.Query().Get("category")
+		var count int
+		deps.DB.QueryRow(`SELECT COUNT(DISTINCT media_path) FROM media_tag_by_category WHERE category_label = ?`, category).Scan(&count)
+		writeJSON(w, count)
+	}
+}
+
 // ---- Category handlers ----
 
 func lokiCreateCategoryHandler(deps *Dependencies) http.HandlerFunc {

--- a/media-server/loki_api.go
+++ b/media-server/loki_api.go
@@ -287,10 +287,15 @@ func lokiMediaQueryHandler(deps *Dependencies) http.HandlerFunc {
 			var description sql.NullString
 			var elo sql.NullFloat64
 			var height, width sql.NullInt64
-			if err := rows.Scan(&path, &description, &elo, &height, &width); err != nil {
+			var weight sql.NullFloat64
+			var tagLabel sql.NullString
+			var timeStamp sql.NullFloat64
+			var createdAt sql.NullInt64
+			if err := rows.Scan(&path, &description, &elo, &height, &width,
+				&weight, &tagLabel, &timeStamp, &createdAt); err != nil {
 				continue
 			}
-			item := map[string]any{"path": path}
+			item := map[string]any{"path": path, "mtimeMs": createdAt.Int64}
 			if description.Valid {
 				item["description"] = description.String
 			}
@@ -298,10 +303,19 @@ func lokiMediaQueryHandler(deps *Dependencies) http.HandlerFunc {
 				item["elo"] = elo.Float64
 			}
 			if height.Valid {
-				item["height"] = int(height.Int64)
+				item["height"] = height.Int64
 			}
 			if width.Valid {
-				item["width"] = int(width.Int64)
+				item["width"] = width.Int64
+			}
+			if weight.Valid {
+				item["weight"] = weight.Float64
+			}
+			if tagLabel.Valid {
+				item["tagLabel"] = tagLabel.String
+			}
+			if timeStamp.Valid {
+				item["timeStamp"] = timeStamp.Float64
 			}
 			items = append(items, item)
 		}

--- a/media-server/loki_api.go
+++ b/media-server/loki_api.go
@@ -284,21 +284,20 @@ func lokiMediaQueryHandler(deps *Dependencies) http.HandlerFunc {
 		items := []map[string]any{}
 		for rows.Next() {
 			var path string
-			var description sql.NullString
 			var elo sql.NullFloat64
 			var height, width sql.NullInt64
 			var weight sql.NullFloat64
 			var tagLabel sql.NullString
 			var timeStamp sql.NullFloat64
 			var createdAt sql.NullInt64
-			if err := rows.Scan(&path, &description, &elo, &height, &width,
+			// 8 columns, matching BuildMediaQuery — description is filtered but
+			// never selected: path, elo, height, width, weight, tag_label,
+			// time_stamp, created_at.
+			if err := rows.Scan(&path, &elo, &height, &width,
 				&weight, &tagLabel, &timeStamp, &createdAt); err != nil {
 				continue
 			}
 			item := map[string]any{"path": path, "mtimeMs": createdAt.Int64}
-			if description.Valid {
-				item["description"] = description.String
-			}
 			if elo.Valid {
 				item["elo"] = elo.Float64
 			}

--- a/media-server/main.go
+++ b/media-server/main.go
@@ -2467,6 +2467,8 @@ func main() {
 	mux.HandleFunc("/api/taxonomy", renderer.ApplyMiddlewares(lokiTaxonomyHandler(deps), renderer.RoleAdmin))
 	mux.HandleFunc("/api/taxonomy/categories", renderer.ApplyMiddlewares(lokiCategoriesHandler(deps), renderer.RoleAdmin))
 	mux.HandleFunc("/api/taxonomy/tags", renderer.ApplyMiddlewares(lokiTaxonomyTagsHandler(deps), renderer.RoleAdmin))
+	mux.HandleFunc("/api/taxonomy/paths", renderer.ApplyMiddlewares(lokiPathSuggestHandler(deps), renderer.RoleAdmin))
+	mux.HandleFunc("/api/taxonomy/category-count", renderer.ApplyMiddlewares(lokiCategoryCountHandler(deps), renderer.RoleAdmin))
 
 	mux.HandleFunc("/api/tags", renderer.ApplyMiddlewares(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {

--- a/media-server/main.go
+++ b/media-server/main.go
@@ -732,8 +732,10 @@ func mediaSuggestHandler(deps *Dependencies) http.HandlerFunc {
 			_ = json.NewEncoder(w).Encode(respSimple{Suggestions: suggestions})
 			return
 		case "tag":
-			// Return structured tags with categories for grouping (no pagination - returns all tags)
-			tags, err := media.SuggestTagsWithCategories(deps.DB, prefix)
+			// Return structured tags with categories for grouping, capped by
+			// `limit` so a short substring against a 100k+ tag library can't
+			// return tens of thousands of rows and freeze the typeahead.
+			tags, err := media.SuggestTagsWithCategories(deps.DB, prefix, limit)
 			if err != nil {
 				log.Printf("suggest error kind=%s prefix=%q: %v", kind, prefix, err)
 				http.Error(w, "suggest error", http.StatusInternalServerError)

--- a/media-server/main.go
+++ b/media-server/main.go
@@ -2456,6 +2456,7 @@ func main() {
 		}
 	}, renderer.RoleAdmin))
 	mux.HandleFunc("/api/media/search", renderer.ApplyMiddlewares(lokiMediaSearchHandler(deps), renderer.RoleAdmin))
+	mux.HandleFunc("/api/media/query", renderer.ApplyMiddlewares(lokiMediaQueryHandler(deps), renderer.RoleAdmin))
 	mux.HandleFunc("/api/media/metadata", renderer.ApplyMiddlewares(lokiMediaMetadataHandler(deps), renderer.RoleAdmin))
 	mux.HandleFunc("/api/media/tags", renderer.ApplyMiddlewares(lokiMediaTagsHandler(deps), renderer.RoleAdmin))
 	mux.HandleFunc("/api/media/description", renderer.ApplyMiddlewares(lokiUpdateDescriptionHandler(deps), renderer.RoleAdmin))

--- a/media-server/main_darwin.go
+++ b/media-server/main_darwin.go
@@ -2267,6 +2267,8 @@ func main() {
 	mux.HandleFunc("/api/taxonomy", renderer.ApplyMiddlewares(lokiTaxonomyHandler(deps), renderer.RoleAdmin))
 	mux.HandleFunc("/api/taxonomy/categories", renderer.ApplyMiddlewares(lokiCategoriesHandler(deps), renderer.RoleAdmin))
 	mux.HandleFunc("/api/taxonomy/tags", renderer.ApplyMiddlewares(lokiTaxonomyTagsHandler(deps), renderer.RoleAdmin))
+	mux.HandleFunc("/api/taxonomy/paths", renderer.ApplyMiddlewares(lokiPathSuggestHandler(deps), renderer.RoleAdmin))
+	mux.HandleFunc("/api/taxonomy/category-count", renderer.ApplyMiddlewares(lokiCategoryCountHandler(deps), renderer.RoleAdmin))
 
 	mux.HandleFunc("/api/tags", renderer.ApplyMiddlewares(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {

--- a/media-server/main_darwin.go
+++ b/media-server/main_darwin.go
@@ -2256,6 +2256,7 @@ func main() {
 		}
 	}, renderer.RoleAdmin))
 	mux.HandleFunc("/api/media/search", renderer.ApplyMiddlewares(lokiMediaSearchHandler(deps), renderer.RoleAdmin))
+	mux.HandleFunc("/api/media/query", renderer.ApplyMiddlewares(lokiMediaQueryHandler(deps), renderer.RoleAdmin))
 	mux.HandleFunc("/api/media/metadata", renderer.ApplyMiddlewares(lokiMediaMetadataHandler(deps), renderer.RoleAdmin))
 	mux.HandleFunc("/api/media/tags", renderer.ApplyMiddlewares(lokiMediaTagsHandler(deps), renderer.RoleAdmin))
 	mux.HandleFunc("/api/media/description", renderer.ApplyMiddlewares(lokiUpdateDescriptionHandler(deps), renderer.RoleAdmin))

--- a/media-server/main_darwin.go
+++ b/media-server/main_darwin.go
@@ -724,8 +724,10 @@ func mediaSuggestHandler(deps *Dependencies) http.HandlerFunc {
 			_ = json.NewEncoder(w).Encode(respSimple{Suggestions: suggestions})
 			return
 		case "tag":
-			// Return structured tags with categories for grouping (no pagination - returns all tags)
-			tags, err := media.SuggestTagsWithCategories(deps.DB, prefix)
+			// Return structured tags with categories for grouping, capped by
+			// `limit` so a short substring against a 100k+ tag library can't
+			// return tens of thousands of rows and freeze the typeahead.
+			tags, err := media.SuggestTagsWithCategories(deps.DB, prefix, limit)
 			if err != nil {
 				log.Printf("suggest error kind=%s prefix=%q: %v", kind, prefix, err)
 				http.Error(w, "suggest error", http.StatusInternalServerError)

--- a/media-server/main_linux.go
+++ b/media-server/main_linux.go
@@ -2267,6 +2267,8 @@ func main() {
 	mux.HandleFunc("/api/taxonomy", renderer.ApplyMiddlewares(lokiTaxonomyHandler(deps), renderer.RoleAdmin))
 	mux.HandleFunc("/api/taxonomy/categories", renderer.ApplyMiddlewares(lokiCategoriesHandler(deps), renderer.RoleAdmin))
 	mux.HandleFunc("/api/taxonomy/tags", renderer.ApplyMiddlewares(lokiTaxonomyTagsHandler(deps), renderer.RoleAdmin))
+	mux.HandleFunc("/api/taxonomy/paths", renderer.ApplyMiddlewares(lokiPathSuggestHandler(deps), renderer.RoleAdmin))
+	mux.HandleFunc("/api/taxonomy/category-count", renderer.ApplyMiddlewares(lokiCategoryCountHandler(deps), renderer.RoleAdmin))
 
 	mux.HandleFunc("/api/tags", renderer.ApplyMiddlewares(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {

--- a/media-server/main_linux.go
+++ b/media-server/main_linux.go
@@ -2256,6 +2256,7 @@ func main() {
 		}
 	}, renderer.RoleAdmin))
 	mux.HandleFunc("/api/media/search", renderer.ApplyMiddlewares(lokiMediaSearchHandler(deps), renderer.RoleAdmin))
+	mux.HandleFunc("/api/media/query", renderer.ApplyMiddlewares(lokiMediaQueryHandler(deps), renderer.RoleAdmin))
 	mux.HandleFunc("/api/media/metadata", renderer.ApplyMiddlewares(lokiMediaMetadataHandler(deps), renderer.RoleAdmin))
 	mux.HandleFunc("/api/media/tags", renderer.ApplyMiddlewares(lokiMediaTagsHandler(deps), renderer.RoleAdmin))
 	mux.HandleFunc("/api/media/description", renderer.ApplyMiddlewares(lokiUpdateDescriptionHandler(deps), renderer.RoleAdmin))

--- a/media-server/main_linux.go
+++ b/media-server/main_linux.go
@@ -724,8 +724,10 @@ func mediaSuggestHandler(deps *Dependencies) http.HandlerFunc {
 			_ = json.NewEncoder(w).Encode(respSimple{Suggestions: suggestions})
 			return
 		case "tag":
-			// Return structured tags with categories for grouping (no pagination - returns all tags)
-			tags, err := media.SuggestTagsWithCategories(deps.DB, prefix)
+			// Return structured tags with categories for grouping, capped by
+			// `limit` so a short substring against a 100k+ tag library can't
+			// return tens of thousands of rows and freeze the typeahead.
+			tags, err := media.SuggestTagsWithCategories(deps.DB, prefix, limit)
 			if err != nil {
 				log.Printf("suggest error kind=%s prefix=%q: %v", kind, prefix, err)
 				http.Error(w, "suggest error", http.StatusInternalServerError)

--- a/media-server/media/get_paths_by_query_test.go
+++ b/media-server/media/get_paths_by_query_test.go
@@ -67,6 +67,62 @@ func TestGetPathsByQuery_UnparseableQueryErrors(t *testing.T) {
 	}
 }
 
+// seedNestedMedia inserts a directory with a file directly inside it plus a
+// file in a subdirectory, so we can distinguish a one-level match from a
+// recursive one.
+func seedNestedMedia(t *testing.T, db *sql.DB) {
+	t.Helper()
+	paths := []string{
+		"/lib/cats/top.jpg",        // directly in /lib/cats
+		"/lib/cats/sub/nested.jpg", // one level deeper
+		"/lib/dogs/other.jpg",      // sibling dir — never matched
+	}
+	for _, p := range paths {
+		if _, err := db.Exec("INSERT INTO media (path) VALUES (?)", p); err != nil {
+			t.Fatalf("insert media %s: %v", p, err)
+		}
+	}
+}
+
+// TestGetPathsByQuery_PathDirIsOneLevel pins the non-recursive contract the
+// context palette relies on: pathdir matches only files directly in the
+// directory, not files in subdirectories.
+func TestGetPathsByQuery_PathDirIsOneLevel(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedNestedMedia(t, db)
+
+	paths, err := GetPathsByQuery(db, `pathdir:"/lib/cats"`)
+	if err != nil {
+		t.Fatalf("GetPathsByQuery() error = %v", err)
+	}
+	if len(paths) != 1 || paths[0] != "/lib/cats/top.jpg" {
+		t.Fatalf("pathdir matched %v, want only [/lib/cats/top.jpg]", paths)
+	}
+}
+
+// TestGetPathsByQuery_WildcardPathIsRecursive pins the recursive contract: the
+// trailing-wildcard path query the context palette emits when recursive
+// browsing is on matches every file under the directory, at any depth.
+func TestGetPathsByQuery_WildcardPathIsRecursive(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedNestedMedia(t, db)
+
+	paths, err := GetPathsByQuery(db, `path:"/lib/cats/*"`)
+	if err != nil {
+		t.Fatalf("GetPathsByQuery() error = %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("wildcard path matched %d paths, want 2 (top + nested) (%v)", len(paths), paths)
+	}
+	for _, p := range paths {
+		if p == "/lib/dogs/other.jpg" {
+			t.Fatalf("wildcard path leaked a sibling directory: %v", paths)
+		}
+	}
+}
+
 // TestGetPathsByQuery_EmptyQuerySelectsAll confirms the legitimate "no filter"
 // case still returns everything — only parse *failures* are treated as errors.
 func TestGetPathsByQuery_EmptyQuerySelectsAll(t *testing.T) {

--- a/media-server/media/get_paths_by_query_test.go
+++ b/media-server/media/get_paths_by_query_test.go
@@ -1,0 +1,84 @@
+package media
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// seedTaggedMedia inserts a small fixture: two files tagged "Exchange Student"
+// and one untagged file, so we can prove a tag query selects a subset rather
+// than the whole table.
+func seedTaggedMedia(t *testing.T, db *sql.DB) {
+	t.Helper()
+	rows := []struct {
+		path, tag string
+	}{
+		{"/lib/a.jpg", "Exchange Student"},
+		{"/lib/b.jpg", "Exchange Student"},
+		{"/lib/c.jpg", ""}, // untagged — must NOT be selected by the tag query
+	}
+	for _, r := range rows {
+		if _, err := db.Exec("INSERT INTO media (path) VALUES (?)", r.path); err != nil {
+			t.Fatalf("insert media %s: %v", r.path, err)
+		}
+		if r.tag != "" {
+			if _, err := db.Exec(
+				"INSERT INTO media_tag_by_category (media_path, tag_label, category_label) VALUES (?, ?, ?)",
+				r.path, r.tag, "people"); err != nil {
+				t.Fatalf("insert tag for %s: %v", r.path, err)
+			}
+		}
+	}
+}
+
+// TestGetPathsByQuery_QuotedMultiWordTag verifies that a properly quoted
+// multi-word tag value selects exactly the tagged subset. This is the query the
+// renderer now emits for tags containing spaces.
+func TestGetPathsByQuery_QuotedMultiWordTag(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedTaggedMedia(t, db)
+
+	paths, err := GetPathsByQuery(db, `tag:"Exchange Student"`)
+	if err != nil {
+		t.Fatalf("GetPathsByQuery() error = %v", err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("quoted tag query selected %d paths, want 2 (%v)", len(paths), paths)
+	}
+}
+
+// TestGetPathsByQuery_UnparseableQueryErrors is the regression guard for the
+// reported bug: an unquoted multi-word tag (`tag:Exchange Student`) fails to
+// parse. Previously this silently fell back to selecting the ENTIRE library,
+// so a "describe these files" job ran against every item. It must now return an
+// error so the calling job fails loudly instead.
+func TestGetPathsByQuery_UnparseableQueryErrors(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedTaggedMedia(t, db)
+
+	paths, err := GetPathsByQuery(db, "tag:Exchange Student")
+	if err == nil {
+		t.Fatalf("expected an error for an unparseable query, got %d paths (%v)", len(paths), paths)
+	}
+	if paths != nil {
+		t.Fatalf("expected no paths on parse failure, got %v", paths)
+	}
+}
+
+// TestGetPathsByQuery_EmptyQuerySelectsAll confirms the legitimate "no filter"
+// case still returns everything — only parse *failures* are treated as errors.
+func TestGetPathsByQuery_EmptyQuerySelectsAll(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedTaggedMedia(t, db)
+
+	paths, err := GetPathsByQuery(db, "")
+	if err != nil {
+		t.Fatalf("GetPathsByQuery() error = %v", err)
+	}
+	if len(paths) != 3 {
+		t.Fatalf("empty query selected %d paths, want 3 (all) (%v)", len(paths), paths)
+	}
+}

--- a/media-server/media/get_random_items_tagfast_test.go
+++ b/media-server/media/get_random_items_tagfast_test.go
@@ -1,0 +1,141 @@
+package media
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+)
+
+// extractTagFilter must recognise exactly the "pure tag predicates joined by a
+// single operator" shapes the swipe filter produces, and reject anything that
+// would need the generic media-table query.
+func TestExtractTagFilter(t *testing.T) {
+	parseKind := func(q string) ([]string, tagFilterKind) {
+		node, err := NewParser(q).Parse()
+		if err != nil {
+			t.Fatalf("parse %q: %v", q, err)
+		}
+		return extractTagFilter(node)
+	}
+
+	t.Run("single tag", func(t *testing.T) {
+		labels, kind := parseKind(`tag:"swipe"`)
+		if kind != tagFilterLeaf {
+			t.Fatalf("kind = %v, want leaf", kind)
+		}
+		if len(labels) != 1 || labels[0] != "swipe" {
+			t.Fatalf("labels = %v", labels)
+		}
+	})
+
+	t.Run("OR union", func(t *testing.T) {
+		labels, kind := parseKind(`tag:"a" OR tag:"b" OR tag:"c"`)
+		if kind != tagFilterOr {
+			t.Fatalf("kind = %v, want or", kind)
+		}
+		sort.Strings(labels)
+		if fmt.Sprint(labels) != "[a b c]" {
+			t.Fatalf("labels = %v", labels)
+		}
+	})
+
+	t.Run("AND intersection", func(t *testing.T) {
+		_, kind := parseKind(`tag:"a" AND tag:"b"`)
+		if kind != tagFilterAnd {
+			t.Fatalf("kind = %v, want and", kind)
+		}
+	})
+
+	t.Run("implicit AND", func(t *testing.T) {
+		_, kind := parseKind(`tag:"a" tag:"b"`)
+		if kind != tagFilterAnd {
+			t.Fatalf("kind = %v, want and", kind)
+		}
+	})
+
+	rejects := map[string]string{
+		"mixed AND/OR":  `tag:"a" OR (tag:"b" AND tag:"c")`,
+		"non-tag path":  `path:"x"`,
+		"NOT tag":       `NOT tag:"a"`,
+		"tag wildcard":  `tag:"a*"`,
+		"category":      `category:"x"`,
+		"tag plus path": `tag:"a" AND path:"x"`,
+		"tagcount":      `tagcount:>2`,
+	}
+	for name, q := range rejects {
+		t.Run("reject "+name, func(t *testing.T) {
+			_, kind := parseKind(q)
+			if kind != tagFilterNone {
+				t.Fatalf("kind = %v, want none for %q", kind, q)
+			}
+		})
+	}
+}
+
+// The fast tag path must return the correct union / intersection sets — the
+// same results the generic path would, just resolved straight from
+// media_tag_by_category.
+func TestGetRandomItemsTagUnionAndIntersection(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// m1: A,B   m2: A   m3: B   m4: (untagged-ish) C
+	fixtures := map[string][]string{
+		"/m/1.jpg": {"A", "B"},
+		"/m/2.jpg": {"A"},
+		"/m/3.jpg": {"B"},
+		"/m/4.jpg": {"C"},
+	}
+	for path, tags := range fixtures {
+		if _, err := db.Exec(
+			`INSERT INTO media (path, description, size, hash, width, height) VALUES (?, ?, ?, ?, ?, ?)`,
+			path, nil, 1, path, 10, 10,
+		); err != nil {
+			t.Fatalf("insert media %s: %v", path, err)
+		}
+		for _, tg := range tags {
+			if _, err := db.Exec(
+				`INSERT INTO media_tag_by_category (media_path, tag_label, category_label) VALUES (?, ?, ?)`,
+				path, tg, "cat",
+			); err != nil {
+				t.Fatalf("insert tag %s/%s: %v", path, tg, err)
+			}
+		}
+	}
+
+	pathsOf := func(items []MediaItem) []string {
+		out := make([]string, 0, len(items))
+		for _, it := range items {
+			out = append(out, it.Path)
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	// Union: A or B -> m1, m2, m3.
+	union, _, err := GetRandomItems(db, 0, 50, `tag:"A" OR tag:"B"`, 7)
+	if err != nil {
+		t.Fatalf("union: %v", err)
+	}
+	if got := fmt.Sprint(pathsOf(union)); got != "[/m/1.jpg /m/2.jpg /m/3.jpg]" {
+		t.Fatalf("union paths = %s", got)
+	}
+
+	// Intersection: A and B -> only m1.
+	inter, _, err := GetRandomItems(db, 0, 50, `tag:"A" AND tag:"B"`, 7)
+	if err != nil {
+		t.Fatalf("intersection: %v", err)
+	}
+	if got := fmt.Sprint(pathsOf(inter)); got != "[/m/1.jpg]" {
+		t.Fatalf("intersection paths = %s", got)
+	}
+
+	// Single tag -> m1, m2.
+	single, _, err := GetRandomItems(db, 0, 50, `tag:"A"`, 7)
+	if err != nil {
+		t.Fatalf("single: %v", err)
+	}
+	if got := fmt.Sprint(pathsOf(single)); got != "[/m/1.jpg /m/2.jpg]" {
+		t.Fatalf("single paths = %s", got)
+	}
+}

--- a/media-server/media/media.go
+++ b/media-server/media/media.go
@@ -382,14 +382,25 @@ func getTaggedPathsByLabels(db *sql.DB, labels []string, intersect bool) ([]stri
 		args = append(args, l)
 	}
 
+	// EXISTS(media) is load-bearing for pagination, not just a tidiness filter:
+	// media_tag_by_category can hold paths whose media row was deleted (dangling
+	// tags). Such a path produces no item from the downstream wide SELECT, so
+	// including it makes a page return fewer items than the shuffle window it
+	// consumed. The swipe client advances its offset by items received while the
+	// server advances by `limit`; the two then diverge and windows overlap,
+	// re-serving the same items — the "swipe loops over the same set" bug, acute
+	// for high-orphan tags. Constraining the universe to paths with a media row
+	// keeps the 1:1 path→item mapping the client's offset assumes.
 	var query string
 	if intersect && len(uniq) > 1 {
 		query = `SELECT media_path FROM media_tag_by_category WHERE tag_label IN (` +
-			placeholders + `) GROUP BY media_path HAVING COUNT(DISTINCT tag_label) = ? ORDER BY media_path`
+			placeholders + `) AND EXISTS (SELECT 1 FROM media m WHERE m.path = media_path)` +
+			` GROUP BY media_path HAVING COUNT(DISTINCT tag_label) = ? ORDER BY media_path`
 		args = append(args, len(uniq))
 	} else {
 		query = `SELECT DISTINCT media_path FROM media_tag_by_category WHERE tag_label IN (` +
-			placeholders + `) ORDER BY media_path`
+			placeholders + `) AND EXISTS (SELECT 1 FROM media m WHERE m.path = media_path)` +
+			` ORDER BY media_path`
 	}
 
 	stop := querylog.Start("GetRandomItems.tagfast.paths", query, args)

--- a/media-server/media/media.go
+++ b/media-server/media/media.go
@@ -1709,8 +1709,14 @@ func GetPathsByQuery(db *sql.DB, searchQuery string) ([]string, error) {
 		var err error
 		rootNode, err = parser.Parse()
 		if err != nil {
+			// Unlike GetItems (which powers the browse UI and can safely degrade
+			// to showing everything), this function feeds batch tasks that ACT on
+			// the result — describe, move, remove, autotag, transcode. Silently
+			// selecting the whole library on a parse error is catastrophic there
+			// (e.g. an unquoted multi-word tag like `tag:Exchange Student`). Fail
+			// loudly so the calling job errors instead of running on everything.
 			log.Printf("Search query parsing failed: %v", err)
-			rootNode = nil
+			return nil, fmt.Errorf("invalid selection query %q: %w", searchQuery, err)
 		}
 	}
 

--- a/media-server/media/media.go
+++ b/media-server/media/media.go
@@ -1300,11 +1300,17 @@ func SuggestTagLabels(db *sql.DB, prefix string, limit int) ([]string, error) {
 	return out, nil
 }
 
-// SuggestTagsWithCategories returns tags with their categories, grouped and ordered
-// No limit is applied - returns all matching tags since they are grouped by category
-func SuggestTagsWithCategories(db *sql.DB, prefix string) ([]MediaTag, error) {
+// SuggestTagsWithCategories returns tags with their categories, grouped and
+// ordered, capped at `limit` rows. The cap matters: a library with 100k+ tags
+// matches tens of thousands of them on a short substring, and returning every
+// match froze the typeahead (huge JSON payload + one DOM node per tag in the
+// dropdown). `limit` is clamped to a sane range; pass the request's limit.
+func SuggestTagsWithCategories(db *sql.DB, prefix string, limit int) ([]MediaTag, error) {
 	if db == nil {
 		return nil, fmt.Errorf("database connection not available")
+	}
+	if limit <= 0 || limit > 200 {
+		limit = 25
 	}
 	like := "%" + escapeLikePattern(strings.TrimSpace(prefix)) + "%"
 	// Source the list from the `tag` registry (one row per tag) rather than
@@ -1323,7 +1329,8 @@ func SuggestTagsWithCategories(db *sql.DB, prefix string) ([]MediaTag, error) {
         FROM tag
         WHERE label COLLATE NOCASE LIKE ? ESCAPE '\'
         ORDER BY category_label, label
-    `, like)
+        LIMIT ?
+    `, like, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/media-server/media/media.go
+++ b/media-server/media/media.go
@@ -259,6 +259,22 @@ func GetRandomItems(db *sql.DB, offset, limit int, searchQuery string, seed int6
 		}
 	}
 
+	// Fast path for pure tag union/intersection queries — the swipe filter
+	// case (`tag:"X"` or `tag:"X" OR tag:"Y"`). Resolve matching paths straight
+	// from media_tag_by_category by tag_label instead of scanning the whole
+	// media table with a correlated EXISTS per row. Downstream shuffle/paginate
+	// is shared with the generic path so behaviour is identical.
+	if labels, kind := extractTagFilter(rootNode); kind != tagFilterNone {
+		allPaths, err := getTaggedPathsByLabels(db, labels, kind == tagFilterAnd)
+		if err != nil {
+			return nil, false, err
+		}
+		if len(allPaths) == 0 {
+			return nil, false, nil
+		}
+		return assembleRandomItemsFromPaths(db, allPaths, offset, limit, seed)
+	}
+
 	// Build WHERE clause
 	if rootNode != nil {
 		sqlPart, sqlArgs := rootNode.ToSQL()
@@ -327,6 +343,85 @@ func GetRandomItems(db *sql.DB, offset, limit int, searchQuery string, seed int6
 	}
 	stopPaths(len(allPaths), nil)
 
+	if len(allPaths) == 0 {
+		return nil, false, nil
+	}
+
+	return assembleRandomItemsFromPaths(db, allPaths, offset, limit, seed)
+}
+
+// getTaggedPathsByLabels resolves the media paths carrying the given tag labels
+// straight from media_tag_by_category, ordered by path for a stable shuffle
+// input. This avoids the generic path's full media-table scan with a correlated
+// EXISTS per row — the swipe filter only needs tag_label. With intersect=false
+// (union) it returns paths having *any* of the labels; with intersect=true it
+// returns only paths having *all* of them.
+func getTaggedPathsByLabels(db *sql.DB, labels []string, intersect bool) ([]string, error) {
+	// De-duplicate labels (and drop empties) so the IN-list and the
+	// intersection HAVING count are correct.
+	seen := make(map[string]struct{}, len(labels))
+	uniq := make([]string, 0, len(labels))
+	for _, l := range labels {
+		if l == "" {
+			continue
+		}
+		if _, ok := seen[l]; ok {
+			continue
+		}
+		seen[l] = struct{}{}
+		uniq = append(uniq, l)
+	}
+	if len(uniq) == 0 {
+		return nil, nil
+	}
+
+	placeholders := strings.Repeat("?,", len(uniq))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]interface{}, 0, len(uniq)+1)
+	for _, l := range uniq {
+		args = append(args, l)
+	}
+
+	var query string
+	if intersect && len(uniq) > 1 {
+		query = `SELECT media_path FROM media_tag_by_category WHERE tag_label IN (` +
+			placeholders + `) GROUP BY media_path HAVING COUNT(DISTINCT tag_label) = ? ORDER BY media_path`
+		args = append(args, len(uniq))
+	} else {
+		query = `SELECT DISTINCT media_path FROM media_tag_by_category WHERE tag_label IN (` +
+			placeholders + `) ORDER BY media_path`
+	}
+
+	stop := querylog.Start("GetRandomItems.tagfast.paths", query, args)
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		stop(-1, err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	paths := make([]string, 0, 1024)
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			stop(len(paths), err)
+			return nil, err
+		}
+		paths = append(paths, p)
+	}
+	if err := rows.Err(); err != nil {
+		stop(len(paths), err)
+		return nil, err
+	}
+	stop(len(paths), nil)
+	return paths, nil
+}
+
+// assembleRandomItemsFromPaths shuffles allPaths deterministically by seed,
+// paginates [offset, offset+limit), fetches the full media rows for that page
+// via PK point lookups, attaches tags, and checks file existence. Shared by the
+// generic filtered path and the fast tag-only path so both behave identically.
+func assembleRandomItemsFromPaths(db *sql.DB, allPaths []string, offset, limit int, seed int64) ([]MediaItem, bool, error) {
 	if len(allPaths) == 0 {
 		return nil, false, nil
 	}

--- a/media-server/media/random_sampler.go
+++ b/media-server/media/random_sampler.go
@@ -181,7 +181,15 @@ func (s *randomSampler) runBuild(db *sql.DB, ch chan struct{}) {
 // Sorting pins the input order so the same seed always reproduces the
 // same shuffle for an unchanged universe.
 func (s *randomSampler) queryPaths(db *sql.DB) ([]string, error) {
-	const q = `SELECT DISTINCT media_path FROM media_tag_by_category ORDER BY media_path`
+	// EXISTS(media) excludes dangling tags (a media_path whose media row was
+	// deleted). Such a path yields no row from the downstream IN-list lookup, so
+	// leaving it in the universe makes a page return fewer items than the
+	// shuffle window it consumed — the swipe client (offset = items received)
+	// then drifts behind the server's window and re-sees items. Keeping the
+	// universe to paths with a media row preserves the 1:1 path→item mapping.
+	const q = `SELECT DISTINCT mtbc.media_path FROM media_tag_by_category mtbc ` +
+		`WHERE EXISTS (SELECT 1 FROM media m WHERE m.path = mtbc.media_path) ` +
+		`ORDER BY mtbc.media_path`
 	stop := querylog.Start("randomSampler.build", q, nil)
 	rows, err := db.Query(q)
 	if err != nil {

--- a/media-server/media/random_sampler_repro_test.go
+++ b/media-server/media/random_sampler_repro_test.go
@@ -40,6 +40,15 @@ func TestSamplerQueryPathsSorted(t *testing.T) {
 		"/m/charlie.jpg",
 	}
 	for _, p := range insertOrder {
+		// queryPaths now requires a matching media row (it excludes dangling
+		// tags so the swipe page→item mapping stays 1:1), so each tagged path
+		// must also exist in media for this test to exercise real output.
+		if _, err := db.Exec(
+			`INSERT INTO media (path, description, size, hash, width, height) VALUES (?, NULL, 1, ?, 10, 10)`,
+			p, p,
+		); err != nil {
+			t.Fatalf("seed media insert: %v", err)
+		}
 		if _, err := db.Exec(
 			`INSERT INTO media_tag_by_category (media_path, tag_label, category_label) VALUES (?, 'x', 'c')`,
 			p,
@@ -48,10 +57,30 @@ func TestSamplerQueryPathsSorted(t *testing.T) {
 		}
 	}
 
+	// A dangling tag (no media row) must be excluded from the universe — leaving
+	// it in makes swipe pages return fewer items than the window they consume,
+	// which drifts the client's offset and re-serves items.
+	if _, err := db.Exec(
+		`INSERT INTO media_tag_by_category (media_path, tag_label, category_label) VALUES ('/m/orphan.jpg', 'x', 'c')`,
+	); err != nil {
+		t.Fatalf("seed orphan: %v", err)
+	}
+
 	s := &randomSampler{}
 	got, err := s.queryPaths(db)
 	if err != nil {
 		t.Fatalf("queryPaths: %v", err)
+	}
+
+	// Guard against the change silently returning nothing: the sort check below
+	// is vacuous on an empty slice. The orphan must not appear.
+	if len(got) != len(insertOrder) {
+		t.Fatalf("queryPaths returned %d paths, want %d (every seeded path has a media row; the orphan must be excluded)", len(got), len(insertOrder))
+	}
+	for _, p := range got {
+		if p == "/m/orphan.jpg" {
+			t.Fatalf("queryPaths returned dangling tag /m/orphan.jpg; paths without a media row must be excluded")
+		}
 	}
 
 	for i := 1; i < len(got); i++ {

--- a/media-server/media/search.go
+++ b/media-server/media/search.go
@@ -504,6 +504,53 @@ func (n *ConditionNode) HasDuplicates() bool {
 	return n.Column == "duplicates"
 }
 
+// tagFilterKind classifies a parsed query for the fast tag-only path.
+type tagFilterKind int
+
+const (
+	tagFilterNone tagFilterKind = iota // not a pure tag query — use the generic path
+	tagFilterLeaf                      // a single tag:"x"
+	tagFilterOr                        // tags joined only by OR (union)
+	tagFilterAnd                       // tags joined only by AND (intersection)
+)
+
+// extractTagFilter reports whether `node` is composed *solely* of `tag:"x"`
+// equality predicates joined by a single boolean operator (all-OR or all-AND).
+// When it is, the swipe filter can be answered with a direct lookup on
+// media_tag_by_category by tag_label, avoiding a full media-table scan with a
+// correlated EXISTS per row. Anything else (wildcards/LIKE, NOT, mixed
+// AND/OR, or any non-tag predicate) returns tagFilterNone so the caller falls
+// back to the generic query builder.
+func extractTagFilter(node Node) (labels []string, kind tagFilterKind) {
+	switch n := node.(type) {
+	case *ConditionNode:
+		if n.Column == "tag" && n.Operator == "=" && n.Value != "" {
+			return []string{n.Value}, tagFilterLeaf
+		}
+		return nil, tagFilterNone
+	case *OrNode:
+		l, lk := extractTagFilter(n.Left)
+		r, rk := extractTagFilter(n.Right)
+		// Both sides must be tag-only and must not contain an AND group —
+		// mixing AND under OR isn't a flat union, so bail to the generic path.
+		if lk == tagFilterNone || rk == tagFilterNone || lk == tagFilterAnd || rk == tagFilterAnd {
+			return nil, tagFilterNone
+		}
+		return append(l, r...), tagFilterOr
+	case *AndNode:
+		l, lk := extractTagFilter(n.Left)
+		r, rk := extractTagFilter(n.Right)
+		// Both sides must be tag-only and must not contain an OR group.
+		if lk == tagFilterNone || rk == tagFilterNone || lk == tagFilterOr || rk == tagFilterOr {
+			return nil, tagFilterNone
+		}
+		return append(l, r...), tagFilterAnd
+	default:
+		// NotNode, nil, or anything else — not a pure tag query.
+		return nil, tagFilterNone
+	}
+}
+
 // Helper functions for comparison
 func compareString(val, op, target string) bool {
 	val = strings.ToLower(val)

--- a/media-server/media/suggest_tags_test.go
+++ b/media-server/media/suggest_tags_test.go
@@ -1,0 +1,82 @@
+package media
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// setupTagRegistryDB creates the `tag` registry table SuggestTagsWithCategories
+// reads from and seeds it with `n` tags that all share a common substring, so a
+// short prefix matches every one of them.
+func setupTagRegistryDB(t *testing.T, n int) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec(`CREATE TABLE tag (
+		label TEXT PRIMARY KEY,
+		category_label TEXT,
+		weight REAL,
+		preview TEXT,
+		thumbnail_path_600 TEXT
+	)`); err != nil {
+		t.Fatalf("create tag table: %v", err)
+	}
+	for i := 0; i < n; i++ {
+		if _, err := db.Exec(
+			`INSERT INTO tag (label, category_label) VALUES (?, ?)`,
+			fmt.Sprintf("cat_tag_%05d", i), "Suggested",
+		); err != nil {
+			t.Fatalf("insert tag %d: %v", i, err)
+		}
+	}
+	return db
+}
+
+// A short substring against a large tag set must not return everything — the
+// result is capped at the requested limit. This is the typeahead-freeze guard.
+func TestSuggestTagsWithCategories_RespectsLimit(t *testing.T) {
+	db := setupTagRegistryDB(t, 5000)
+
+	tags, err := SuggestTagsWithCategories(db, "tag", 50)
+	if err != nil {
+		t.Fatalf("SuggestTagsWithCategories: %v", err)
+	}
+	if len(tags) != 50 {
+		t.Fatalf("got %d tags, want 50 (capped)", len(tags))
+	}
+}
+
+// A non-positive or oversized limit falls back to the default cap rather than
+// returning the whole table.
+func TestSuggestTagsWithCategories_ClampsLimit(t *testing.T) {
+	db := setupTagRegistryDB(t, 5000)
+
+	for _, lim := range []int{0, -1, 9999} {
+		tags, err := SuggestTagsWithCategories(db, "tag", lim)
+		if err != nil {
+			t.Fatalf("limit=%d: %v", lim, err)
+		}
+		if len(tags) != 25 {
+			t.Fatalf("limit=%d: got %d tags, want 25 (default clamp)", lim, len(tags))
+		}
+	}
+}
+
+// The prefix still filters: a substring that matches nothing returns nothing.
+func TestSuggestTagsWithCategories_FiltersByPrefix(t *testing.T) {
+	db := setupTagRegistryDB(t, 100)
+
+	tags, err := SuggestTagsWithCategories(db, "no_such_substring", 50)
+	if err != nil {
+		t.Fatalf("SuggestTagsWithCategories: %v", err)
+	}
+	if len(tags) != 0 {
+		t.Fatalf("got %d tags, want 0 for a non-matching prefix", len(tags))
+	}
+}

--- a/media-server/media/swipe_orphan_pagination_test.go
+++ b/media-server/media/swipe_orphan_pagination_test.go
@@ -1,0 +1,96 @@
+package media
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestSwipeFilterPaginationSkipsOrphansNoRepeats reproduces the swipe
+// "loops over the same set of images before continuing" bug for tag-filtered
+// swipe.
+//
+// Root cause: the fast tag path resolves candidate paths straight from
+// media_tag_by_category, which can contain paths whose media row was deleted
+// (orphans). assembleRandomItemsFromPaths drops those when the wide SELECT
+// finds no media row, so a page returns FEWER items than the shuffle window it
+// consumed. The swipe client advances its offset by the number of items it
+// received (offset = items.length), while the server advances its shuffle
+// window by `limit`. When the two diverge, consecutive windows overlap and the
+// same real items get re-served over and over — pronounced when a tag has a
+// high orphan rate (a real tag in the library has 105 orphans out of 114
+// paths).
+//
+// The fix constrains the swipe universe to paths that actually have a media
+// row, so every sampled path yields exactly one item and the client's
+// offset stays aligned with the server's shuffle position.
+func TestSwipeFilterPaginationSkipsOrphansNoRepeats(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	const tag = "loop"
+
+	// 10 real paths: present in BOTH media and media_tag_by_category.
+	real := make([]string, 0, 10)
+	for i := 0; i < 10; i++ {
+		p := fmt.Sprintf("/m/real-%02d.jpg", i)
+		real = append(real, p)
+		if _, err := db.Exec(
+			`INSERT INTO media (path, description, size, hash, width, height) VALUES (?,?,?,?,?,?)`,
+			p, nil, 1, p, 10, 10,
+		); err != nil {
+			t.Fatalf("insert media %s: %v", p, err)
+		}
+		if _, err := db.Exec(
+			`INSERT INTO media_tag_by_category (media_path, tag_label, category_label) VALUES (?,?,?)`,
+			p, tag, "cat",
+		); err != nil {
+			t.Fatalf("insert tag %s: %v", p, err)
+		}
+	}
+
+	// 30 orphan paths: tagged but NO media row (deleted media, dangling tags).
+	for i := 0; i < 30; i++ {
+		p := fmt.Sprintf("/m/orphan-%02d.jpg", i)
+		if _, err := db.Exec(
+			`INSERT INTO media_tag_by_category (media_path, tag_label, category_label) VALUES (?,?,?)`,
+			p, tag, "cat",
+		); err != nil {
+			t.Fatalf("insert orphan tag %s: %v", p, err)
+		}
+	}
+
+	// Paginate exactly like the swipe client: stable seed, and the next offset
+	// is the count of items received so far (offset = items.length).
+	const seed = int64(42)
+	const limit = 5
+	seen := map[string]int{}
+	offset := 0
+	for iter := 0; iter < 100; iter++ {
+		items, hasMore, err := GetRandomItems(db, offset, limit, `tag:"loop"`, seed)
+		if err != nil {
+			t.Fatalf("page at offset %d: %v", offset, err)
+		}
+		for _, it := range items {
+			seen[it.Path]++
+		}
+		if !hasMore {
+			break
+		}
+		if len(items) == 0 {
+			// Server says "more" but returned nothing: the client's offset can
+			// never catch up to the shuffle window — the swipe view wedges.
+			t.Fatalf("page returned 0 items with hasMore=true at offset %d: pagination cannot progress", offset)
+		}
+		offset += len(items)
+	}
+
+	// Every real item must be served exactly once; orphans never appear.
+	for p, n := range seen {
+		if n != 1 {
+			t.Errorf("path %s served %d times; swipe pagination must not repeat items", p, n)
+		}
+	}
+	if len(seen) != len(real) {
+		t.Errorf("saw %d distinct items, want %d real items (orphans must be excluded, reals must all appear once)", len(seen), len(real))
+	}
+}

--- a/media-server/media_query.go
+++ b/media-server/media_query.go
@@ -1,0 +1,74 @@
+// media-server/media_query.go
+package main
+
+import "strings"
+
+// Predicate mirrors src/renderer/query/types.ts Predicate.
+type Predicate struct {
+	Type    string `json:"type"`    // tag|category|path|description|hash
+	Value   string `json:"value"`
+	Exclude bool   `json:"exclude"`
+}
+
+const baseSelect = "SELECT media.path, media.description, media.elo, media.height, media.width FROM media"
+
+func clauseFor(p Predicate, params *[]any) string {
+	like := "%" + p.Value + "%"
+	switch p.Type {
+	case "tag":
+		*params = append(*params, p.Value)
+		if p.Exclude {
+			return "(NOT EXISTS (SELECT 1 FROM media_tag_by_category mtc WHERE mtc.media_path = media.path AND mtc.tag_label = ?))"
+		}
+		return "(EXISTS (SELECT 1 FROM media_tag_by_category mtc WHERE mtc.media_path = media.path AND mtc.tag_label = ?))"
+	case "category":
+		*params = append(*params, p.Value)
+		if p.Exclude {
+			return "(NOT EXISTS (SELECT 1 FROM media_tag_by_category mtc WHERE mtc.media_path = media.path AND mtc.category_label = ?))"
+		}
+		return "(EXISTS (SELECT 1 FROM media_tag_by_category mtc WHERE mtc.media_path = media.path AND mtc.category_label = ?))"
+	case "path":
+		*params = append(*params, like)
+		if p.Exclude {
+			return "(media.path NOT LIKE ?)"
+		}
+		return "(media.path LIKE ?)"
+	case "description":
+		*params = append(*params, like)
+		if p.Exclude {
+			return "(media.description NOT LIKE ?)"
+		}
+		return "(media.description LIKE ?)"
+	case "hash":
+		*params = append(*params, like)
+		if p.Exclude {
+			return "(media.hash NOT LIKE ?)"
+		}
+		return "(media.hash LIKE ?)"
+	}
+	return ""
+}
+
+// BuildMediaQuery returns the SQL and ordered params for the given predicates.
+// mode AND -> AND join, OR -> OR join, EXCLUSIVE -> AND join (single by design).
+func BuildMediaQuery(predicates []Predicate, mode string) (string, []any) {
+	params := []any{}
+	clauses := []string{}
+	for _, p := range predicates {
+		if p.Value == "" {
+			continue
+		}
+		c := clauseFor(p, &params)
+		if c != "" {
+			clauses = append(clauses, c)
+		}
+	}
+	if len(clauses) == 0 {
+		return baseSelect, params
+	}
+	joiner := " AND "
+	if mode == "OR" {
+		joiner = " OR "
+	}
+	return baseSelect + " WHERE " + strings.Join(clauses, joiner), params
+}

--- a/media-server/media_query.go
+++ b/media-server/media_query.go
@@ -5,13 +5,24 @@ import "strings"
 
 // Predicate mirrors src/renderer/query/types.ts Predicate.
 type Predicate struct {
-	Type    string `json:"type"`    // tag|category|path|description|hash
+	Type    string `json:"type"` // tag|category|path|description|hash
 	Value   string `json:"value"`
 	Exclude bool   `json:"exclude"`
 	Join    string `json:"join"` // "AND" | "OR" | "" (empty falls back to mode)
 }
 
-const baseColumns = "media.path, media.description, media.elo, media.height, media.width"
+// Columns returned for the library list. media.description is intentionally
+// NOT selected (large text the list view doesn't use; the detail view fetches
+// it on demand) — it's still available as a WHERE filter via clauseFor. The
+// renderer sorts results, so queries emit no ORDER BY. Mirror of query-sql.ts.
+const baseColumns = "media.path, media.elo, media.height, media.width"
+
+// Aliased column list for the index-driven paths, matching the TS builder so
+// the handler scans the same 8 columns by position regardless of path:
+// path, elo, height, width, weight, tag_label, time_stamp, created_at.
+const drivenColumns = "mtcw.media_path AS path, media.elo AS elo, media.height AS height, " +
+	"media.width AS width, mtcw.weight AS weight, mtcw.tag_label AS tag_label, " +
+	"mtcw.time_stamp AS time_stamp, mtcw.created_at AS created_at"
 
 func clauseFor(p Predicate, params *[]any) string {
 	like := "%" + p.Value + "%"
@@ -50,9 +61,31 @@ func clauseFor(p Predicate, params *[]any) string {
 	return ""
 }
 
-// BuildMediaQuery returns SQL + params. Always selects 9 columns (the 4 tag
-// columns are NULL unless there's an include-tag to LEFT JOIN on) so the
-// handler can scan by position regardless of predicate mix.
+// facetedWhere combines predicates: AND-bucket clauses are required, the
+// OR-bucket is grouped as "(a OR b ...)". Returns "" when there are none.
+func facetedWhere(preds []Predicate, joinOf func(Predicate) string, params *[]any) string {
+	andClauses := []string{}
+	orClauses := []string{}
+	for _, p := range preds {
+		if joinOf(p) != "OR" {
+			andClauses = append(andClauses, clauseFor(p, params))
+		}
+	}
+	for _, p := range preds {
+		if joinOf(p) == "OR" {
+			orClauses = append(orClauses, clauseFor(p, params))
+		}
+	}
+	pieces := append([]string{}, andClauses...)
+	if len(orClauses) > 0 {
+		pieces = append(pieces, "("+strings.Join(orClauses, " OR ")+")")
+	}
+	return strings.Join(pieces, " AND ")
+}
+
+// BuildMediaQuery returns SQL + params for the unified query. It drives tag
+// queries from the indexed media_tag_by_category lookup (avoiding a full
+// `media` scan) wherever semantics allow, mirroring src/main/query-sql.ts.
 func BuildMediaQuery(predicates []Predicate, mode string) (string, []any) {
 	valid := []Predicate{}
 	for _, p := range predicates {
@@ -61,32 +94,9 @@ func BuildMediaQuery(predicates []Predicate, mode string) (string, []any) {
 		}
 	}
 
-	// First INCLUDE tag drives the LEFT JOIN that surfaces weight/tag/timestamp.
-	primaryTag := ""
-	for _, p := range valid {
-		if p.Type == "tag" && !p.Exclude {
-			primaryTag = p.Value
-			break
-		}
-	}
-
-	params := []any{}
-	var selectClause, order string
-	if primaryTag != "" {
-		selectClause = "SELECT " + baseColumns +
-			", mtcw.weight AS weight, mtcw.tag_label AS tag_label, " +
-			"mtcw.time_stamp AS time_stamp, mtcw.created_at AS created_at " +
-			"FROM media LEFT JOIN media_tag_by_category mtcw " +
-			"ON mtcw.media_path = media.path AND mtcw.tag_label = ?"
-		params = append(params, primaryTag) // JOIN param first
-		order = " ORDER BY mtcw.weight"
-	} else {
-		selectClause = "SELECT " + baseColumns +
-			", NULL AS weight, NULL AS tag_label, NULL AS time_stamp, NULL AS created_at FROM media"
-	}
-
 	if len(valid) == 0 {
-		return selectClause, params
+		return "SELECT " + baseColumns +
+			", NULL AS weight, NULL AS tag_label, NULL AS time_stamp, NULL AS created_at FROM media", []any{}
 	}
 
 	defaultJoin := "AND"
@@ -99,25 +109,87 @@ func BuildMediaQuery(predicates []Predicate, mode string) (string, []any) {
 		}
 		return defaultJoin
 	}
-	andClauses := []string{}
-	orClauses := []string{}
-	for _, p := range valid {
-		if joinOf(p) != "OR" {
-			andClauses = append(andClauses, clauseFor(p, &params))
+	isIncludeTag := func(p Predicate) bool { return p.Type == "tag" && !p.Exclude }
+
+	// Fast path: drive from a REQUIRED include-tag (AND-bucket, or the sole
+	// predicate) via the indexed tag lookup instead of scanning `media`.
+	driveIdx := -1
+	for i := range valid {
+		if isIncludeTag(valid[i]) && joinOf(valid[i]) != "OR" {
+			driveIdx = i
+			break
 		}
 	}
+	if driveIdx == -1 && len(valid) == 1 && isIncludeTag(valid[0]) {
+		driveIdx = 0
+	}
+
+	if driveIdx >= 0 {
+		params := []any{valid[driveIdx].Value} // driving join param first
+		rest := []Predicate{}
+		for i := range valid {
+			if i != driveIdx {
+				rest = append(rest, valid[i])
+			}
+		}
+		restWhere := facetedWhere(rest, joinOf, &params)
+		extra := ""
+		if restWhere != "" {
+			extra = " AND " + restWhere
+		}
+		sql := "SELECT " + drivenColumns +
+			" FROM media_tag_by_category mtcw LEFT JOIN media ON media.path = mtcw.media_path" +
+			" WHERE mtcw.tag_label = ?" + extra
+		return sql, params
+	}
+
+	// OR-set of include-tags: every predicate is an include-tag (an OR bucket)
+	// — "media with ANY of these tags" = tag_label IN (...). Indexed lookup.
+	allIncludeTags := true
 	for _, p := range valid {
-		if joinOf(p) == "OR" {
-			orClauses = append(orClauses, clauseFor(p, &params))
+		if !isIncludeTag(p) {
+			allIncludeTags = false
+			break
 		}
 	}
-	pieces := append([]string{}, andClauses...)
-	if len(orClauses) > 0 {
-		pieces = append(pieces, "("+strings.Join(orClauses, " OR ")+")")
+	if allIncludeTags {
+		params := []any{}
+		placeholders := []string{}
+		for _, p := range valid {
+			params = append(params, p.Value)
+			placeholders = append(placeholders, "?")
+		}
+		sql := "SELECT " + drivenColumns +
+			" FROM media_tag_by_category mtcw LEFT JOIN media ON media.path = mtcw.media_path" +
+			" WHERE mtcw.tag_label IN (" + strings.Join(placeholders, ", ") + ")"
+		return sql, params
 	}
+
+	// Fallback: exclude-only, non-tag predicates, or an OR bucket mixing tags
+	// with non-tags. Scan media; LEFT JOIN the first include-tag (if any) only
+	// to surface weight/tag/timestamp columns.
+	primaryTag := ""
+	for _, p := range valid {
+		if isIncludeTag(p) {
+			primaryTag = p.Value
+			break
+		}
+	}
+	params := []any{}
+	var selectClause string
+	if primaryTag != "" {
+		selectClause = "SELECT " + baseColumns +
+			", mtcw.weight AS weight, mtcw.tag_label AS tag_label, mtcw.time_stamp AS time_stamp, mtcw.created_at AS created_at" +
+			" FROM media LEFT JOIN media_tag_by_category mtcw ON mtcw.media_path = media.path AND mtcw.tag_label = ?"
+		params = append(params, primaryTag)
+	} else {
+		selectClause = "SELECT " + baseColumns +
+			", NULL AS weight, NULL AS tag_label, NULL AS time_stamp, NULL AS created_at FROM media"
+	}
+	restWhere := facetedWhere(valid, joinOf, &params)
 	where := ""
-	if len(pieces) > 0 {
-		where = " WHERE " + strings.Join(pieces, " AND ")
+	if restWhere != "" {
+		where = " WHERE " + restWhere
 	}
-	return selectClause + where + order, params
+	return selectClause + where, params
 }

--- a/media-server/media_query.go
+++ b/media-server/media_query.go
@@ -110,6 +110,10 @@ func BuildMediaQuery(predicates []Predicate, mode string) (string, []any) {
 		return defaultJoin
 	}
 	isIncludeTag := func(p Predicate) bool { return p.Type == "tag" && !p.Exclude }
+	isIncludeCat := func(p Predicate) bool { return p.Type == "category" && !p.Exclude }
+	// Tag columns are NULL for category-driven queries (a category spans many
+	// tags, so there's no single per-tag weight/timestamp).
+	const nullTagCols = "NULL AS weight, NULL AS tag_label, NULL AS time_stamp, NULL AS created_at"
 
 	// Fast path: drive from a REQUIRED include-tag (AND-bucket, or the sole
 	// predicate) via the indexed tag lookup instead of scanning `media`.
@@ -143,6 +147,39 @@ func BuildMediaQuery(predicates []Predicate, mode string) (string, []any) {
 		return sql, params
 	}
 
+	// Category fast path: drive from a REQUIRED include-category (AND-bucket or
+	// the sole predicate) via the indexed category lookup; collapse to DISTINCT
+	// media_path (one row per media) with NULL tag columns.
+	catIdx := -1
+	for i := range valid {
+		if isIncludeCat(valid[i]) && joinOf(valid[i]) != "OR" {
+			catIdx = i
+			break
+		}
+	}
+	if catIdx == -1 && len(valid) == 1 && isIncludeCat(valid[0]) {
+		catIdx = 0
+	}
+	if catIdx >= 0 {
+		params := []any{valid[catIdx].Value}
+		rest := []Predicate{}
+		for i := range valid {
+			if i != catIdx {
+				rest = append(rest, valid[i])
+			}
+		}
+		restWhere := facetedWhere(rest, joinOf, &params)
+		where := ""
+		if restWhere != "" {
+			where = " WHERE " + restWhere
+		}
+		sql := "SELECT media.path AS path, media.elo AS elo, media.height AS height, media.width AS width, " +
+			nullTagCols +
+			" FROM (SELECT DISTINCT media_path FROM media_tag_by_category WHERE category_label = ?) cat" +
+			" JOIN media ON media.path = cat.media_path" + where
+		return sql, params
+	}
+
 	// OR-set of include-tags: every predicate is an include-tag (an OR bucket)
 	// — "media with ANY of these tags" = tag_label IN (...). Indexed lookup.
 	allIncludeTags := true
@@ -162,6 +199,29 @@ func BuildMediaQuery(predicates []Predicate, mode string) (string, []any) {
 		sql := "SELECT " + drivenColumns +
 			" FROM media_tag_by_category mtcw LEFT JOIN media ON media.path = mtcw.media_path" +
 			" WHERE mtcw.tag_label IN (" + strings.Join(placeholders, ", ") + ")"
+		return sql, params
+	}
+
+	// OR-set of include-categories: category_label IN (...), DISTINCT media.
+	allIncludeCats := true
+	for _, p := range valid {
+		if !isIncludeCat(p) {
+			allIncludeCats = false
+			break
+		}
+	}
+	if allIncludeCats {
+		params := []any{}
+		placeholders := []string{}
+		for _, p := range valid {
+			params = append(params, p.Value)
+			placeholders = append(placeholders, "?")
+		}
+		sql := "SELECT media.path AS path, media.elo AS elo, media.height AS height, media.width AS width, " +
+			nullTagCols +
+			" FROM (SELECT DISTINCT media_path FROM media_tag_by_category WHERE category_label IN (" +
+			strings.Join(placeholders, ", ") + ")) cat" +
+			" JOIN media ON media.path = cat.media_path"
 		return sql, params
 	}
 

--- a/media-server/media_query.go
+++ b/media-server/media_query.go
@@ -17,6 +17,9 @@ type Predicate struct {
 // renderer sorts results, so queries emit no ORDER BY. Mirror of query-sql.ts.
 const baseColumns = "media.path, media.elo, media.height, media.width"
 
+// Tag columns are NULL for category-driven / no-tag queries.
+const nullTagCols = "NULL AS weight, NULL AS tag_label, NULL AS time_stamp, NULL AS created_at"
+
 // Aliased column list for the index-driven paths, matching the TS builder so
 // the handler scans the same 8 columns by position regardless of path:
 // path, elo, height, width, weight, tag_label, time_stamp, created_at.
@@ -61,173 +64,23 @@ func clauseFor(p Predicate, params *[]any) string {
 	return ""
 }
 
-// facetedWhere combines predicates: AND-bucket clauses are required, the
-// OR-bucket is grouped as "(a OR b ...)". Returns "" when there are none.
-func facetedWhere(preds []Predicate, joinOf func(Predicate) string, params *[]any) string {
-	andClauses := []string{}
-	orClauses := []string{}
+func isIncludeTag(p Predicate) bool { return p.Type == "tag" && !p.Exclude }
+func isIncludeCat(p Predicate) bool { return p.Type == "category" && !p.Exclude }
+
+// andJoin joins clauses for the conjunct "rest" of an intersection fast path.
+func andJoin(preds []Predicate, params *[]any) string {
+	clauses := []string{}
 	for _, p := range preds {
-		if joinOf(p) != "OR" {
-			andClauses = append(andClauses, clauseFor(p, params))
-		}
+		clauses = append(clauses, clauseFor(p, params))
 	}
-	for _, p := range preds {
-		if joinOf(p) == "OR" {
-			orClauses = append(orClauses, clauseFor(p, params))
-		}
-	}
-	pieces := append([]string{}, andClauses...)
-	if len(orClauses) > 0 {
-		pieces = append(pieces, "("+strings.Join(orClauses, " OR ")+")")
-	}
-	return strings.Join(pieces, " AND ")
+	return strings.Join(clauses, " AND ")
 }
 
-// BuildMediaQuery returns SQL + params for the unified query. It drives tag
-// queries from the indexed media_tag_by_category lookup (avoiding a full
-// `media` scan) wherever semantics allow, mirroring src/main/query-sql.ts.
-func BuildMediaQuery(predicates []Predicate, mode string) (string, []any) {
-	valid := []Predicate{}
-	for _, p := range predicates {
-		if p.Value != "" {
-			valid = append(valid, p)
-		}
-	}
-
-	if len(valid) == 0 {
-		return "SELECT " + baseColumns +
-			", NULL AS weight, NULL AS tag_label, NULL AS time_stamp, NULL AS created_at FROM media", []any{}
-	}
-
-	defaultJoin := "AND"
-	if mode == "OR" {
-		defaultJoin = "OR"
-	}
-	joinOf := func(p Predicate) string {
-		if p.Join == "AND" || p.Join == "OR" {
-			return p.Join
-		}
-		return defaultJoin
-	}
-	isIncludeTag := func(p Predicate) bool { return p.Type == "tag" && !p.Exclude }
-	isIncludeCat := func(p Predicate) bool { return p.Type == "category" && !p.Exclude }
-	// Tag columns are NULL for category-driven queries (a category spans many
-	// tags, so there's no single per-tag weight/timestamp).
-	const nullTagCols = "NULL AS weight, NULL AS tag_label, NULL AS time_stamp, NULL AS created_at"
-
-	// Fast path: drive from a REQUIRED include-tag (AND-bucket, or the sole
-	// predicate) via the indexed tag lookup instead of scanning `media`.
-	driveIdx := -1
-	for i := range valid {
-		if isIncludeTag(valid[i]) && joinOf(valid[i]) != "OR" {
-			driveIdx = i
-			break
-		}
-	}
-	if driveIdx == -1 && len(valid) == 1 && isIncludeTag(valid[0]) {
-		driveIdx = 0
-	}
-
-	if driveIdx >= 0 {
-		params := []any{valid[driveIdx].Value} // driving join param first
-		rest := []Predicate{}
-		for i := range valid {
-			if i != driveIdx {
-				rest = append(rest, valid[i])
-			}
-		}
-		restWhere := facetedWhere(rest, joinOf, &params)
-		extra := ""
-		if restWhere != "" {
-			extra = " AND " + restWhere
-		}
-		sql := "SELECT " + drivenColumns +
-			" FROM media_tag_by_category mtcw LEFT JOIN media ON media.path = mtcw.media_path" +
-			" WHERE mtcw.tag_label = ?" + extra
-		return sql, params
-	}
-
-	// Category fast path: drive from a REQUIRED include-category (AND-bucket or
-	// the sole predicate) via the indexed category lookup; collapse to DISTINCT
-	// media_path (one row per media) with NULL tag columns.
-	catIdx := -1
-	for i := range valid {
-		if isIncludeCat(valid[i]) && joinOf(valid[i]) != "OR" {
-			catIdx = i
-			break
-		}
-	}
-	if catIdx == -1 && len(valid) == 1 && isIncludeCat(valid[0]) {
-		catIdx = 0
-	}
-	if catIdx >= 0 {
-		params := []any{valid[catIdx].Value}
-		rest := []Predicate{}
-		for i := range valid {
-			if i != catIdx {
-				rest = append(rest, valid[i])
-			}
-		}
-		restWhere := facetedWhere(rest, joinOf, &params)
-		where := ""
-		if restWhere != "" {
-			where = " WHERE " + restWhere
-		}
-		sql := "SELECT media.path AS path, media.elo AS elo, media.height AS height, media.width AS width, " +
-			nullTagCols +
-			" FROM (SELECT DISTINCT media_path FROM media_tag_by_category WHERE category_label = ?) cat" +
-			" JOIN media ON media.path = cat.media_path" + where
-		return sql, params
-	}
-
-	// OR-set of include-tags: every predicate is an include-tag (an OR bucket)
-	// — "media with ANY of these tags" = tag_label IN (...). Indexed lookup.
-	allIncludeTags := true
-	for _, p := range valid {
-		if !isIncludeTag(p) {
-			allIncludeTags = false
-			break
-		}
-	}
-	if allIncludeTags {
-		params := []any{}
-		placeholders := []string{}
-		for _, p := range valid {
-			params = append(params, p.Value)
-			placeholders = append(placeholders, "?")
-		}
-		sql := "SELECT " + drivenColumns +
-			" FROM media_tag_by_category mtcw LEFT JOIN media ON media.path = mtcw.media_path" +
-			" WHERE mtcw.tag_label IN (" + strings.Join(placeholders, ", ") + ")"
-		return sql, params
-	}
-
-	// OR-set of include-categories: category_label IN (...), DISTINCT media.
-	allIncludeCats := true
-	for _, p := range valid {
-		if !isIncludeCat(p) {
-			allIncludeCats = false
-			break
-		}
-	}
-	if allIncludeCats {
-		params := []any{}
-		placeholders := []string{}
-		for _, p := range valid {
-			params = append(params, p.Value)
-			placeholders = append(placeholders, "?")
-		}
-		sql := "SELECT media.path AS path, media.elo AS elo, media.height AS height, media.width AS width, " +
-			nullTagCols +
-			" FROM (SELECT DISTINCT media_path FROM media_tag_by_category WHERE category_label IN (" +
-			strings.Join(placeholders, ", ") + ")) cat" +
-			" JOIN media ON media.path = cat.media_path"
-		return sql, params
-	}
-
-	// Fallback: exclude-only, non-tag predicates, or an OR bucket mixing tags
-	// with non-tags. Scan media; LEFT JOIN the first include-tag (if any) only
-	// to surface weight/tag/timestamp columns.
+// mediaScan is the always-correct path: scan media and combine clauses
+// LEFT-TO-RIGHT with the given connectors (connectors[i] joins valid[i+1]),
+// parenthesized left-associatively to match how the chips read. Surfaces tag
+// columns via a LEFT JOIN on the first include-tag (if any).
+func mediaScan(valid []Predicate, connectors []string) (string, []any) {
 	primaryTag := ""
 	for _, p := range valid {
 		if isIncludeTag(p) {
@@ -243,13 +96,157 @@ func BuildMediaQuery(predicates []Predicate, mode string) (string, []any) {
 			" FROM media LEFT JOIN media_tag_by_category mtcw ON mtcw.media_path = media.path AND mtcw.tag_label = ?"
 		params = append(params, primaryTag)
 	} else {
-		selectClause = "SELECT " + baseColumns +
-			", NULL AS weight, NULL AS tag_label, NULL AS time_stamp, NULL AS created_at FROM media"
+		selectClause = "SELECT " + baseColumns + ", " + nullTagCols + " FROM media"
 	}
-	restWhere := facetedWhere(valid, joinOf, &params)
-	where := ""
-	if restWhere != "" {
-		where = " WHERE " + restWhere
+	expr := clauseFor(valid[0], &params)
+	for i := 1; i < len(valid); i++ {
+		expr = "(" + expr + " " + connectors[i-1] + " " + clauseFor(valid[i], &params) + ")"
 	}
-	return selectClause + where, params
+	return selectClause + " WHERE " + expr, params
+}
+
+// BuildMediaQuery returns SQL + params. Predicates combine LEFT-TO-RIGHT: the
+// first is the base, each subsequent predicate's Join connects it to the
+// running result. Homogeneous all-AND / all-OR get index-driven fast paths;
+// mixed operators fall back to a correct media scan. Mirror of query-sql.ts.
+func BuildMediaQuery(predicates []Predicate, mode string) (string, []any) {
+	valid := []Predicate{}
+	for _, p := range predicates {
+		if p.Value != "" {
+			valid = append(valid, p)
+		}
+	}
+
+	if len(valid) == 0 {
+		return "SELECT " + baseColumns + ", " + nullTagCols + " FROM media", []any{}
+	}
+
+	defaultJoin := "AND"
+	if mode == "OR" {
+		defaultJoin = "OR"
+	}
+	joinOf := func(p Predicate) string {
+		if p.Join == "AND" || p.Join == "OR" {
+			return p.Join
+		}
+		return defaultJoin
+	}
+
+	// Connectors join each predicate after the first to the running result.
+	connectors := []string{}
+	for i := 1; i < len(valid); i++ {
+		connectors = append(connectors, joinOf(valid[i]))
+	}
+	allOr := len(connectors) > 0
+	for _, c := range connectors {
+		if c != "OR" {
+			allOr = false
+		}
+	}
+	allAnd := true
+	for _, c := range connectors {
+		if c != "AND" {
+			allAnd = false
+		}
+	}
+
+	allTags := true
+	allCats := true
+	for _, p := range valid {
+		if !isIncludeTag(p) {
+			allTags = false
+		}
+		if !isIncludeCat(p) {
+			allCats = false
+		}
+	}
+
+	// ---- Union (all-OR) via an indexed IN lookup ----
+	if allOr && allTags {
+		params := []any{}
+		placeholders := []string{}
+		for _, p := range valid {
+			params = append(params, p.Value)
+			placeholders = append(placeholders, "?")
+		}
+		sql := "SELECT " + drivenColumns +
+			" FROM media_tag_by_category mtcw LEFT JOIN media ON media.path = mtcw.media_path" +
+			" WHERE mtcw.tag_label IN (" + strings.Join(placeholders, ", ") + ")"
+		return sql, params
+	}
+	if allOr && allCats {
+		params := []any{}
+		placeholders := []string{}
+		for _, p := range valid {
+			params = append(params, p.Value)
+			placeholders = append(placeholders, "?")
+		}
+		sql := "SELECT media.path AS path, media.elo AS elo, media.height AS height, media.width AS width, " +
+			nullTagCols +
+			" FROM (SELECT DISTINCT media_path FROM media_tag_by_category WHERE category_label IN (" +
+			strings.Join(placeholders, ", ") + ")) cat" +
+			" JOIN media ON media.path = cat.media_path"
+		return sql, params
+	}
+
+	// ---- Intersection (single predicate or all-AND): drive from an indexed
+	//      tag/category with the rest as AND conjuncts ----
+	if allAnd {
+		driveIdx := -1
+		for i := range valid {
+			if isIncludeTag(valid[i]) {
+				driveIdx = i
+				break
+			}
+		}
+		if driveIdx >= 0 {
+			params := []any{valid[driveIdx].Value}
+			rest := []Predicate{}
+			for i := range valid {
+				if i != driveIdx {
+					rest = append(rest, valid[i])
+				}
+			}
+			restWhere := andJoin(rest, &params)
+			extra := ""
+			if restWhere != "" {
+				extra = " AND " + restWhere
+			}
+			sql := "SELECT " + drivenColumns +
+				" FROM media_tag_by_category mtcw LEFT JOIN media ON media.path = mtcw.media_path" +
+				" WHERE mtcw.tag_label = ?" + extra
+			return sql, params
+		}
+		catIdx := -1
+		for i := range valid {
+			if isIncludeCat(valid[i]) {
+				catIdx = i
+				break
+			}
+		}
+		if catIdx >= 0 {
+			params := []any{valid[catIdx].Value}
+			rest := []Predicate{}
+			for i := range valid {
+				if i != catIdx {
+					rest = append(rest, valid[i])
+				}
+			}
+			restWhere := andJoin(rest, &params)
+			where := ""
+			if restWhere != "" {
+				where = " WHERE " + restWhere
+			}
+			sql := "SELECT media.path AS path, media.elo AS elo, media.height AS height, media.width AS width, " +
+				nullTagCols +
+				" FROM (SELECT DISTINCT media_path FROM media_tag_by_category WHERE category_label = ?) cat" +
+				" JOIN media ON media.path = cat.media_path" + where
+			return sql, params
+		}
+		// No drivable tag/category (paths/hash/excludes only) → AND media scan.
+		return mediaScan(valid, connectors)
+	}
+
+	// ---- Mixed AND/OR operators → correct left-to-right media scan ----
+	return mediaScan(valid, connectors)
 }

--- a/media-server/media_query.go
+++ b/media-server/media_query.go
@@ -11,7 +11,7 @@ type Predicate struct {
 	Join    string `json:"join"` // "AND" | "OR" | "" (empty falls back to mode)
 }
 
-const baseSelect = "SELECT media.path, media.description, media.elo, media.height, media.width FROM media"
+const baseColumns = "media.path, media.description, media.elo, media.height, media.width"
 
 func clauseFor(p Predicate, params *[]any) string {
 	like := "%" + p.Value + "%"
@@ -50,22 +50,45 @@ func clauseFor(p Predicate, params *[]any) string {
 	return ""
 }
 
-// BuildMediaQuery returns the SQL and ordered params for the given predicates.
-// Each predicate's Join field ("AND"/"OR") overrides the global mode for that predicate.
-// AND predicates are required clauses joined by AND; OR predicates are grouped as (c1 OR c2 ...).
-// The final WHERE is: (AND clauses...) AND (OR group), which mirrors the TS faceted query logic.
-// Params are pushed in emission order: AND bucket first, then OR bucket.
+// BuildMediaQuery returns SQL + params. Always selects 9 columns (the 4 tag
+// columns are NULL unless there's an include-tag to LEFT JOIN on) so the
+// handler can scan by position regardless of predicate mix.
 func BuildMediaQuery(predicates []Predicate, mode string) (string, []any) {
-	params := []any{}
 	valid := []Predicate{}
 	for _, p := range predicates {
 		if p.Value != "" {
 			valid = append(valid, p)
 		}
 	}
-	if len(valid) == 0 {
-		return baseSelect, params
+
+	// First INCLUDE tag drives the LEFT JOIN that surfaces weight/tag/timestamp.
+	primaryTag := ""
+	for _, p := range valid {
+		if p.Type == "tag" && !p.Exclude {
+			primaryTag = p.Value
+			break
+		}
 	}
+
+	params := []any{}
+	var selectClause, order string
+	if primaryTag != "" {
+		selectClause = "SELECT " + baseColumns +
+			", mtcw.weight AS weight, mtcw.tag_label AS tag_label, " +
+			"mtcw.time_stamp AS time_stamp, mtcw.created_at AS created_at " +
+			"FROM media LEFT JOIN media_tag_by_category mtcw " +
+			"ON mtcw.media_path = media.path AND mtcw.tag_label = ?"
+		params = append(params, primaryTag) // JOIN param first
+		order = " ORDER BY mtcw.weight"
+	} else {
+		selectClause = "SELECT " + baseColumns +
+			", NULL AS weight, NULL AS tag_label, NULL AS time_stamp, NULL AS created_at FROM media"
+	}
+
+	if len(valid) == 0 {
+		return selectClause, params
+	}
+
 	defaultJoin := "AND"
 	if mode == "OR" {
 		defaultJoin = "OR"
@@ -78,7 +101,6 @@ func BuildMediaQuery(predicates []Predicate, mode string) (string, []any) {
 	}
 	andClauses := []string{}
 	orClauses := []string{}
-	// Emit AND bucket first, then OR bucket, so params line up with ? placeholders.
 	for _, p := range valid {
 		if joinOf(p) != "OR" {
 			andClauses = append(andClauses, clauseFor(p, &params))
@@ -93,5 +115,9 @@ func BuildMediaQuery(predicates []Predicate, mode string) (string, []any) {
 	if len(orClauses) > 0 {
 		pieces = append(pieces, "("+strings.Join(orClauses, " OR ")+")")
 	}
-	return baseSelect + " WHERE " + strings.Join(pieces, " AND "), params
+	where := ""
+	if len(pieces) > 0 {
+		where = " WHERE " + strings.Join(pieces, " AND ")
+	}
+	return selectClause + where + order, params
 }

--- a/media-server/media_query.go
+++ b/media-server/media_query.go
@@ -8,6 +8,7 @@ type Predicate struct {
 	Type    string `json:"type"`    // tag|category|path|description|hash
 	Value   string `json:"value"`
 	Exclude bool   `json:"exclude"`
+	Join    string `json:"join"` // "AND" | "OR" | "" (empty falls back to mode)
 }
 
 const baseSelect = "SELECT media.path, media.description, media.elo, media.height, media.width FROM media"
@@ -50,25 +51,47 @@ func clauseFor(p Predicate, params *[]any) string {
 }
 
 // BuildMediaQuery returns the SQL and ordered params for the given predicates.
-// mode AND -> AND join, OR -> OR join, EXCLUSIVE -> AND join (single by design).
+// Each predicate's Join field ("AND"/"OR") overrides the global mode for that predicate.
+// AND predicates are required clauses joined by AND; OR predicates are grouped as (c1 OR c2 ...).
+// The final WHERE is: (AND clauses...) AND (OR group), which mirrors the TS faceted query logic.
+// Params are pushed in emission order: AND bucket first, then OR bucket.
 func BuildMediaQuery(predicates []Predicate, mode string) (string, []any) {
 	params := []any{}
-	clauses := []string{}
+	valid := []Predicate{}
 	for _, p := range predicates {
-		if p.Value == "" {
-			continue
-		}
-		c := clauseFor(p, &params)
-		if c != "" {
-			clauses = append(clauses, c)
+		if p.Value != "" {
+			valid = append(valid, p)
 		}
 	}
-	if len(clauses) == 0 {
+	if len(valid) == 0 {
 		return baseSelect, params
 	}
-	joiner := " AND "
+	defaultJoin := "AND"
 	if mode == "OR" {
-		joiner = " OR "
+		defaultJoin = "OR"
 	}
-	return baseSelect + " WHERE " + strings.Join(clauses, joiner), params
+	joinOf := func(p Predicate) string {
+		if p.Join == "AND" || p.Join == "OR" {
+			return p.Join
+		}
+		return defaultJoin
+	}
+	andClauses := []string{}
+	orClauses := []string{}
+	// Emit AND bucket first, then OR bucket, so params line up with ? placeholders.
+	for _, p := range valid {
+		if joinOf(p) != "OR" {
+			andClauses = append(andClauses, clauseFor(p, &params))
+		}
+	}
+	for _, p := range valid {
+		if joinOf(p) == "OR" {
+			orClauses = append(orClauses, clauseFor(p, &params))
+		}
+	}
+	pieces := append([]string{}, andClauses...)
+	if len(orClauses) > 0 {
+		pieces = append(pieces, "("+strings.Join(orClauses, " OR ")+")")
+	}
+	return baseSelect + " WHERE " + strings.Join(pieces, " AND "), params
 }

--- a/media-server/media_query_test.go
+++ b/media-server/media_query_test.go
@@ -13,17 +13,31 @@ func TestBuildMediaQueryEmpty(t *testing.T) {
 	if !strings.Contains(norm(sql), "FROM media") {
 		t.Fatalf("expected base query, got %q", sql)
 	}
+	if strings.Contains(sql, "description") {
+		t.Fatalf("description must not be selected: %q", sql)
+	}
 	if len(params) != 0 {
 		t.Fatalf("expected no params, got %v", params)
 	}
 }
 
-func TestBuildMediaQueryTagInclude(t *testing.T) {
+func TestBuildMediaQuerySingleTagDrivesFromIndex(t *testing.T) {
+	// Single include-tag: drive FROM the indexed tag table, no media scan,
+	// no EXISTS, no ORDER BY, description not selected.
 	sql, params := BuildMediaQuery([]Predicate{{Type: "tag", Value: "portrait"}}, "AND")
-	if !strings.Contains(sql, "EXISTS") || !strings.Contains(sql, "mtc.tag_label = ?") {
-		t.Fatalf("bad tag sql: %q", sql)
+	if !strings.Contains(sql, "FROM media_tag_by_category mtcw") {
+		t.Fatalf("expected tag-table drive: %q", sql)
 	}
-	if len(params) != 2 || params[0] != "portrait" || params[1] != "portrait" {
+	if !strings.Contains(sql, "WHERE mtcw.tag_label = ?") {
+		t.Fatalf("expected tag_label filter: %q", sql)
+	}
+	if strings.Contains(sql, "EXISTS") {
+		t.Fatalf("single tag should not use EXISTS: %q", sql)
+	}
+	if strings.Contains(sql, "ORDER BY") || strings.Contains(sql, "description") {
+		t.Fatalf("no ORDER BY / no description expected: %q", sql)
+	}
+	if len(params) != 1 || params[0] != "portrait" {
 		t.Fatalf("bad params: %v", params)
 	}
 }
@@ -35,9 +49,12 @@ func TestBuildMediaQueryLikeWrapping(t *testing.T) {
 		{Type: "hash", Value: "c"},
 	}, "AND")
 	if !strings.Contains(sql, "media.path LIKE ?") ||
-		!strings.Contains(sql, "media.description NOT LIKE ?") ||
+		!strings.Contains(sql, "media.description NOT LIKE ?") || // filtered...
 		!strings.Contains(sql, "media.hash LIKE ?") {
 		t.Fatalf("bad like sql: %q", sql)
+	}
+	if strings.Contains(sql, "AS description") { // ...but not returned
+		t.Fatalf("description must not be selected: %q", sql)
 	}
 	want := []string{"%a%", "%b%", "%c%"}
 	for i := range want {
@@ -47,29 +64,41 @@ func TestBuildMediaQueryLikeWrapping(t *testing.T) {
 	}
 }
 
-func TestBuildMediaQueryOrJoin(t *testing.T) {
-	sql, _ := BuildMediaQuery([]Predicate{
+func TestBuildMediaQueryOrSetUsesInLookup(t *testing.T) {
+	// OR-set of include-tags drives from an indexed tag_label IN, not a scan.
+	sql, params := BuildMediaQuery([]Predicate{
 		{Type: "tag", Value: "a"}, {Type: "tag", Value: "b"},
 	}, "OR")
-	if !strings.Contains(norm(sql), ") OR (") {
-		t.Fatalf("expected OR join: %q", sql)
+	if !strings.Contains(sql, "FROM media_tag_by_category mtcw") ||
+		!strings.Contains(sql, "WHERE mtcw.tag_label IN (?, ?)") {
+		t.Fatalf("expected IN drive: %q", sql)
+	}
+	if strings.Contains(sql, "EXISTS") || strings.Contains(sql, "ORDER BY") {
+		t.Fatalf("no EXISTS / ORDER BY expected: %q", sql)
+	}
+	if len(params) != 2 || params[0] != "a" || params[1] != "b" {
+		t.Fatalf("bad params: %v", params)
 	}
 }
 
 func TestBuildMediaQueryFaceted(t *testing.T) {
+	// a(AND) drives; b/c(OR) become a conjunct OR-group of EXISTS.
 	sql, params := BuildMediaQuery([]Predicate{
 		{Type: "tag", Value: "a", Join: "AND"},
 		{Type: "tag", Value: "b", Join: "OR"},
 		{Type: "tag", Value: "c", Join: "OR"},
 	}, "AND")
 	n := norm(sql)
-	if !strings.Contains(n, ") AND ((") {
-		t.Fatalf("expected AND-required + OR-group: %q", sql)
+	if !strings.Contains(n, "FROM media_tag_by_category mtcw") {
+		t.Fatalf("expected tag-table drive: %q", sql)
+	}
+	if !strings.Contains(n, "WHERE mtcw.tag_label = ?") {
+		t.Fatalf("expected drive filter: %q", sql)
 	}
 	if !strings.Contains(n, ") OR (") {
-		t.Fatalf("expected OR group: %q", sql)
+		t.Fatalf("expected OR group for b/c: %q", sql)
 	}
-	want := []any{"a", "a", "b", "c"}
+	want := []any{"a", "b", "c"} // drive a, then EXISTS b, c
 	if len(params) != len(want) {
 		t.Fatalf("expected %d params, got %d: %v", len(want), len(params), params)
 	}
@@ -80,25 +109,28 @@ func TestBuildMediaQueryFaceted(t *testing.T) {
 	}
 }
 
-func TestBuildMediaQueryJoinOverridesMode(t *testing.T) {
-	sql, _ := BuildMediaQuery([]Predicate{
-		{Type: "tag", Value: "a", Join: "OR"},
-		{Type: "tag", Value: "b", Join: "OR"},
+func TestBuildMediaQueryAndCombo(t *testing.T) {
+	// AND of two tags: drive from the first, second is a conjunct EXISTS.
+	sql, params := BuildMediaQuery([]Predicate{
+		{Type: "tag", Value: "a"}, {Type: "tag", Value: "b"},
 	}, "AND")
-	if !strings.Contains(norm(sql), ") OR (") {
-		t.Fatalf("expected OR join from per-predicate Join: %q", sql)
+	if !strings.Contains(sql, "FROM media_tag_by_category mtcw") ||
+		!strings.Contains(sql, "WHERE mtcw.tag_label = ?") ||
+		!strings.Contains(sql, "AND (EXISTS") {
+		t.Fatalf("expected drive + EXISTS conjunct: %q", sql)
+	}
+	if len(params) != 2 || params[0] != "a" || params[1] != "b" {
+		t.Fatalf("bad params: %v", params)
 	}
 }
 
-func TestBuildMediaQueryIncludeTagJoin(t *testing.T) {
+func TestBuildMediaQueryIncludeTagColumns(t *testing.T) {
 	sql, params := BuildMediaQuery([]Predicate{{Type: "tag", Value: "cat"}}, "AND")
-	if !strings.Contains(sql, "LEFT JOIN media_tag_by_category mtcw") {
-		t.Fatalf("expected left join: %q", sql)
-	}
-	if !strings.Contains(sql, "ORDER BY mtcw.weight") {
-		t.Fatalf("expected order by weight: %q", sql)
+	if !strings.Contains(sql, "mtcw.weight AS weight") ||
+		!strings.Contains(sql, "mtcw.time_stamp AS time_stamp") {
+		t.Fatalf("expected weight/timestamp columns: %q", sql)
 	}
 	if len(params) == 0 || params[0] != "cat" {
-		t.Fatalf("expected join param first: %v", params)
+		t.Fatalf("expected drive param first: %v", params)
 	}
 }

--- a/media-server/media_query_test.go
+++ b/media-server/media_query_test.go
@@ -23,7 +23,7 @@ func TestBuildMediaQueryTagInclude(t *testing.T) {
 	if !strings.Contains(sql, "EXISTS") || !strings.Contains(sql, "mtc.tag_label = ?") {
 		t.Fatalf("bad tag sql: %q", sql)
 	}
-	if len(params) != 1 || params[0] != "portrait" {
+	if len(params) != 2 || params[0] != "portrait" || params[1] != "portrait" {
 		t.Fatalf("bad params: %v", params)
 	}
 }
@@ -69,7 +69,10 @@ func TestBuildMediaQueryFaceted(t *testing.T) {
 	if !strings.Contains(n, ") OR (") {
 		t.Fatalf("expected OR group: %q", sql)
 	}
-	want := []any{"a", "b", "c"}
+	want := []any{"a", "a", "b", "c"}
+	if len(params) != len(want) {
+		t.Fatalf("expected %d params, got %d: %v", len(want), len(params), params)
+	}
 	for i := range want {
 		if params[i] != want[i] {
 			t.Fatalf("param %d = %v want %v", i, params[i], want[i])
@@ -84,5 +87,18 @@ func TestBuildMediaQueryJoinOverridesMode(t *testing.T) {
 	}, "AND")
 	if !strings.Contains(norm(sql), ") OR (") {
 		t.Fatalf("expected OR join from per-predicate Join: %q", sql)
+	}
+}
+
+func TestBuildMediaQueryIncludeTagJoin(t *testing.T) {
+	sql, params := BuildMediaQuery([]Predicate{{Type: "tag", Value: "cat"}}, "AND")
+	if !strings.Contains(sql, "LEFT JOIN media_tag_by_category mtcw") {
+		t.Fatalf("expected left join: %q", sql)
+	}
+	if !strings.Contains(sql, "ORDER BY mtcw.weight") {
+		t.Fatalf("expected order by weight: %q", sql)
+	}
+	if len(params) == 0 || params[0] != "cat" {
+		t.Fatalf("expected join param first: %v", params)
 	}
 }

--- a/media-server/media_query_test.go
+++ b/media-server/media_query_test.go
@@ -55,3 +55,34 @@ func TestBuildMediaQueryOrJoin(t *testing.T) {
 		t.Fatalf("expected OR join: %q", sql)
 	}
 }
+
+func TestBuildMediaQueryFaceted(t *testing.T) {
+	sql, params := BuildMediaQuery([]Predicate{
+		{Type: "tag", Value: "a", Join: "AND"},
+		{Type: "tag", Value: "b", Join: "OR"},
+		{Type: "tag", Value: "c", Join: "OR"},
+	}, "AND")
+	n := norm(sql)
+	if !strings.Contains(n, ") AND ((") {
+		t.Fatalf("expected AND-required + OR-group: %q", sql)
+	}
+	if !strings.Contains(n, ") OR (") {
+		t.Fatalf("expected OR group: %q", sql)
+	}
+	want := []any{"a", "b", "c"}
+	for i := range want {
+		if params[i] != want[i] {
+			t.Fatalf("param %d = %v want %v", i, params[i], want[i])
+		}
+	}
+}
+
+func TestBuildMediaQueryJoinOverridesMode(t *testing.T) {
+	sql, _ := BuildMediaQuery([]Predicate{
+		{Type: "tag", Value: "a", Join: "OR"},
+		{Type: "tag", Value: "b", Join: "OR"},
+	}, "AND")
+	if !strings.Contains(norm(sql), ") OR (") {
+		t.Fatalf("expected OR join from per-predicate Join: %q", sql)
+	}
+}

--- a/media-server/media_query_test.go
+++ b/media-server/media_query_test.go
@@ -109,6 +109,37 @@ func TestBuildMediaQueryFaceted(t *testing.T) {
 	}
 }
 
+func TestBuildMediaQueryCategoryDrivesFromIndex(t *testing.T) {
+	sql, params := BuildMediaQuery([]Predicate{{Type: "category", Value: "Artists"}}, "AND")
+	if !strings.Contains(sql, "SELECT DISTINCT media_path FROM media_tag_by_category WHERE category_label = ?") {
+		t.Fatalf("expected DISTINCT category drive: %q", sql)
+	}
+	if !strings.Contains(sql, "JOIN media ON media.path = cat.media_path") {
+		t.Fatalf("expected join to media: %q", sql)
+	}
+	if !strings.Contains(sql, "NULL AS weight") {
+		t.Fatalf("expected NULL tag columns: %q", sql)
+	}
+	if len(params) != 1 || params[0] != "Artists" {
+		t.Fatalf("bad params: %v", params)
+	}
+}
+
+func TestBuildMediaQueryTagDrivesOverCategory(t *testing.T) {
+	sql, params := BuildMediaQuery([]Predicate{
+		{Type: "tag", Value: "t"}, {Type: "category", Value: "C"},
+	}, "AND")
+	if !strings.Contains(sql, "FROM media_tag_by_category mtcw") {
+		t.Fatalf("expected tag drive: %q", sql)
+	}
+	if !strings.Contains(sql, "mtc.category_label = ?") {
+		t.Fatalf("expected category EXISTS conjunct: %q", sql)
+	}
+	if len(params) != 2 || params[0] != "t" || params[1] != "C" {
+		t.Fatalf("bad params: %v", params)
+	}
+}
+
 func TestBuildMediaQueryAndCombo(t *testing.T) {
 	// AND of two tags: drive from the first, second is a conjunct EXISTS.
 	sql, params := BuildMediaQuery([]Predicate{

--- a/media-server/media_query_test.go
+++ b/media-server/media_query_test.go
@@ -1,0 +1,57 @@
+// media-server/media_query_test.go
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func norm(s string) string { return strings.Join(strings.Fields(s), " ") }
+
+func TestBuildMediaQueryEmpty(t *testing.T) {
+	sql, params := BuildMediaQuery(nil, "AND")
+	if !strings.Contains(norm(sql), "FROM media") {
+		t.Fatalf("expected base query, got %q", sql)
+	}
+	if len(params) != 0 {
+		t.Fatalf("expected no params, got %v", params)
+	}
+}
+
+func TestBuildMediaQueryTagInclude(t *testing.T) {
+	sql, params := BuildMediaQuery([]Predicate{{Type: "tag", Value: "portrait"}}, "AND")
+	if !strings.Contains(sql, "EXISTS") || !strings.Contains(sql, "mtc.tag_label = ?") {
+		t.Fatalf("bad tag sql: %q", sql)
+	}
+	if len(params) != 1 || params[0] != "portrait" {
+		t.Fatalf("bad params: %v", params)
+	}
+}
+
+func TestBuildMediaQueryLikeWrapping(t *testing.T) {
+	sql, params := BuildMediaQuery([]Predicate{
+		{Type: "path", Value: "a"},
+		{Type: "description", Value: "b", Exclude: true},
+		{Type: "hash", Value: "c"},
+	}, "AND")
+	if !strings.Contains(sql, "media.path LIKE ?") ||
+		!strings.Contains(sql, "media.description NOT LIKE ?") ||
+		!strings.Contains(sql, "media.hash LIKE ?") {
+		t.Fatalf("bad like sql: %q", sql)
+	}
+	want := []string{"%a%", "%b%", "%c%"}
+	for i := range want {
+		if params[i] != want[i] {
+			t.Fatalf("param %d = %q want %q", i, params[i], want[i])
+		}
+	}
+}
+
+func TestBuildMediaQueryOrJoin(t *testing.T) {
+	sql, _ := BuildMediaQuery([]Predicate{
+		{Type: "tag", Value: "a"}, {Type: "tag", Value: "b"},
+	}, "OR")
+	if !strings.Contains(norm(sql), ") OR (") {
+		t.Fatalf("expected OR join: %q", sql)
+	}
+}

--- a/media-server/media_query_test.go
+++ b/media-server/media_query_test.go
@@ -81,31 +81,45 @@ func TestBuildMediaQueryOrSetUsesInLookup(t *testing.T) {
 	}
 }
 
-func TestBuildMediaQueryFaceted(t *testing.T) {
-	// a(AND) drives; b/c(OR) become a conjunct OR-group of EXISTS.
+func TestBuildMediaQueryOrJoinUnions(t *testing.T) {
+	// [a, b(OR)] reads "a OR b" — must be a UNION (the reported bug).
 	sql, params := BuildMediaQuery([]Predicate{
+		{Type: "tag", Value: "a"},
+		{Type: "tag", Value: "b", Join: "OR"},
+	}, "AND")
+	if !strings.Contains(sql, "WHERE mtcw.tag_label IN (?, ?)") {
+		t.Fatalf("expected union IN, got %q", sql)
+	}
+	if strings.Contains(sql, "EXISTS") {
+		t.Fatalf("union must not be an intersection: %q", sql)
+	}
+	if len(params) != 2 || params[0] != "a" || params[1] != "b" {
+		t.Fatalf("bad params: %v", params)
+	}
+}
+
+func TestBuildMediaQueryAllOrUnionsEveryTag(t *testing.T) {
+	// First chip's join is ignored (base); all-OR connectors union a,b,c.
+	sql, _ := BuildMediaQuery([]Predicate{
 		{Type: "tag", Value: "a", Join: "AND"},
 		{Type: "tag", Value: "b", Join: "OR"},
 		{Type: "tag", Value: "c", Join: "OR"},
 	}, "AND")
+	if !strings.Contains(sql, "WHERE mtcw.tag_label IN (?, ?, ?)") {
+		t.Fatalf("expected union of all three: %q", sql)
+	}
+}
+
+func TestBuildMediaQueryMixedConnectorsScan(t *testing.T) {
+	// [a, b(OR), c(AND)] reads "(a OR b) AND c" — left-to-right media scan.
+	sql, _ := BuildMediaQuery([]Predicate{
+		{Type: "tag", Value: "a"},
+		{Type: "tag", Value: "b", Join: "OR"},
+		{Type: "tag", Value: "c", Join: "AND"},
+	}, "AND")
 	n := norm(sql)
-	if !strings.Contains(n, "FROM media_tag_by_category mtcw") {
-		t.Fatalf("expected tag-table drive: %q", sql)
-	}
-	if !strings.Contains(n, "WHERE mtcw.tag_label = ?") {
-		t.Fatalf("expected drive filter: %q", sql)
-	}
-	if !strings.Contains(n, ") OR (") {
-		t.Fatalf("expected OR group for b/c: %q", sql)
-	}
-	want := []any{"a", "b", "c"} // drive a, then EXISTS b, c
-	if len(params) != len(want) {
-		t.Fatalf("expected %d params, got %d: %v", len(want), len(params), params)
-	}
-	for i := range want {
-		if params[i] != want[i] {
-			t.Fatalf("param %d = %v want %v", i, params[i], want[i])
-		}
+	if !strings.Contains(n, ") OR (") || !strings.Contains(n, ") AND (") {
+		t.Fatalf("expected left-to-right (a OR b) AND c: %q", sql)
 	}
 }
 

--- a/media-server/renderer/templates/media.go.html
+++ b/media-server/renderer/templates/media.go.html
@@ -4633,7 +4633,11 @@
             return;
           }
           const encPrefix = encodeURIComponent(info.valuePrefix || '');
-          fetch(`/media/suggest?kind=${kind}&prefix=${encPrefix}`)
+          // Cap the result set. With a 100k+ tag library a short substring
+          // matches tens of thousands of tags; returning them all froze the
+          // dropdown (huge payload + one DOM node per row). Paired with the
+          // 150ms input debounce above, this keeps the typeahead snappy.
+          fetch(`/media/suggest?kind=${kind}&prefix=${encPrefix}&limit=50`)
             .then((r) => r.json())
             .then((data) => {
               if (reqId !== lastReqId) return;

--- a/media-server/renderer/templates/swipe.go.html
+++ b/media-server/renderer/templates/swipe.go.html
@@ -877,6 +877,37 @@
         padding: 8px;
       }
 
+      /* Collapsible category header (browse mode) */
+      .tag-category-header.collapsible {
+        cursor: pointer;
+        gap: 8px;
+        user-select: none;
+      }
+
+      .tag-category-header.collapsible:active {
+        background: rgba(0, 0, 0, 0.85);
+      }
+
+      .tag-category-chevron {
+        display: inline-block;
+        width: 12px;
+        font-size: 11px;
+        color: var(--accent);
+        opacity: 0.8;
+      }
+
+      /* Loading / empty placeholder row inside an expanded category */
+      .tag-item-placeholder {
+        color: var(--text-dim);
+        opacity: 0.6;
+        cursor: default;
+        font-style: italic;
+      }
+
+      .tag-item-placeholder:active {
+        transform: none;
+      }
+
       .tag-item {
         padding: 0 14px;
         background: rgba(255, 255, 255, 0.05);
@@ -1468,10 +1499,23 @@
       const longPressIndicator = document.getElementById('longPressIndicator');
       const tagToast = document.getElementById('tagToast');
 
+      // The catch-all autotag bucket. Excluded everywhere in the swipe route's
+      // tag UI (filter list, search, quick-add menu).
+      const EXCLUDED_CATEGORY = 'Suggested';
+
       // Tag filter state
-      let allTags = [];
+      let allTags = []; // full tag list, loaded lazily only when searching
       let selectedTags = new Set();
-      let filteredTags = [];
+      let filteredTags = []; // search results (search mode only)
+
+      // Browse-mode (collapsed categories) state for the filter list.
+      let tagCategoriesList = []; // [{label}] excluding EXCLUDED_CATEGORY
+      let tagCategoriesLoaded = false;
+      let tagCategoriesLoading = null;
+      const expandedCategories = new Set();
+      const categoryTagsCache = {}; // label -> [{label, category}]
+      const categoryTagsLoading = {}; // label -> Promise (dedupe)
+      let tagSearchTerm = '';
 
       // Long press / Quick tag menu state
       let tagMenuCategories = [];
@@ -2697,42 +2741,111 @@
         }
       }
 
-      // Tag filtering functions
-      // Module-level cache state: once loaded, allTags persists for the
-      // page's lifetime. With up to ~10k tags, the network + JSON parse
-      // shouldn't repeat every time the filter modal opens.
-      let allTagsLoaded = false;
-      let allTagsLoading = null; // in-flight Promise to dedupe concurrent opens
+      // Tag loading. The filter list opens in "browse" mode showing collapsed
+      // category headers only — no tags are fetched until a category is
+      // expanded. Searching switches to "search" mode, which lazily loads the
+      // full tag list once and filters it client-side. The catch-all
+      // "Suggested" category is excluded throughout.
 
-      async function loadAllTags(force = false) {
-        if (!force && allTagsLoaded) {
+      // Load the category list (collapsed headers). Cached for the page life.
+      async function loadCategories(force = false) {
+        if (!force && tagCategoriesLoaded) {
           renderTagList();
           return;
         }
-        if (allTagsLoading) {
-          return allTagsLoading;
-        }
-        tagList.innerHTML = '<div class="tag-list-empty">Loading tags...</div>';
-        allTagsLoading = (async () => {
+        if (tagCategoriesLoading) return tagCategoriesLoading;
+        tagList.innerHTML =
+          '<div class="tag-list-empty">Loading categories...</div>';
+        tagCategoriesLoading = (async () => {
           try {
-            const response = await fetch('/media/suggest?kind=tag&prefix=');
+            const response = await fetch('/api/taxonomy/categories');
             const data = await response.json();
-            allTags = (data.tags || []).map((tag) => ({
-              label: tag.label,
-              category: tag.category,
-            }));
-            filteredTags = [...allTags];
-            allTagsLoaded = true;
+            tagCategoriesList = (data || [])
+              .filter((c) => c.label && c.label !== EXCLUDED_CATEGORY)
+              .map((c) => ({ label: c.label }));
+            tagCategoriesLoaded = true;
             renderTagList();
           } catch (err) {
-            console.error('Failed to load tags:', err);
+            console.error('Failed to load categories:', err);
             tagList.innerHTML =
-              '<div class="tag-list-empty">Failed to load tags</div>';
+              '<div class="tag-list-empty">Failed to load categories</div>';
+          } finally {
+            tagCategoriesLoading = null;
+          }
+        })();
+        return tagCategoriesLoading;
+      }
+
+      // Load every tag in one category (only when it's expanded). Cached.
+      async function loadCategoryTags(category) {
+        if (categoryTagsCache[category]) return categoryTagsCache[category];
+        if (categoryTagsLoading[category]) return categoryTagsLoading[category];
+        categoryTagsLoading[category] = (async () => {
+          try {
+            const response = await fetch(
+              '/api/taxonomy/tags?category=' + encodeURIComponent(category)
+            );
+            const data = await response.json();
+            const tags = (data || [])
+              .filter((t) => t.category !== EXCLUDED_CATEGORY)
+              .map((t) => ({ label: t.label, category: t.category }));
+            categoryTagsCache[category] = tags;
+            return tags;
+          } catch (err) {
+            console.error('Failed to load tags for category:', category, err);
+            return [];
+          } finally {
+            categoryTagsLoading[category] = null;
+          }
+        })();
+        return categoryTagsLoading[category];
+      }
+
+      // Lazily load the full tag list (used by search so it can match the
+      // entire library, not just what's been expanded). Cached for the page.
+      let allTagsLoaded = false;
+      let allTagsLoading = null;
+      async function loadAllTagsForSearch() {
+        if (allTagsLoaded) return allTags;
+        if (allTagsLoading) return allTagsLoading;
+        allTagsLoading = (async () => {
+          try {
+            const response = await fetch('/api/taxonomy/tags');
+            const data = await response.json();
+            allTags = (data || [])
+              .filter((t) => t.category !== EXCLUDED_CATEGORY)
+              .map((t) => ({ label: t.label, category: t.category }));
+            allTagsLoaded = true;
+            return allTags;
+          } catch (err) {
+            console.error('Failed to load tags:', err);
+            return [];
           } finally {
             allTagsLoading = null;
           }
         })();
         return allTagsLoading;
+      }
+
+      // Expand/collapse a category in browse mode; lazily fetch its tags the
+      // first time it's opened.
+      async function toggleCategory(category) {
+        if (expandedCategories.has(category)) {
+          expandedCategories.delete(category);
+          renderTagList(false);
+          return;
+        }
+        expandedCategories.add(category);
+        if (!categoryTagsCache[category]) {
+          renderTagList(false); // show the "Loading…" placeholder row immediately
+          await loadCategoryTags(category);
+          // Only re-render if it's still expanded and we're still browsing.
+          if (expandedCategories.has(category) && !tagSearchTerm) {
+            renderTagList(false);
+          }
+        } else {
+          renderTagList(false);
+        }
       }
 
       function renderSelectedTags() {
@@ -2780,29 +2893,71 @@
       function buildVirtualRows() {
         virtualRows = [];
         virtualTotalHeight = 0;
-        if (filteredTags.length === 0) return;
 
-        const byCategory = {};
-        filteredTags.forEach((tag) => {
-          const cat = tag.category || 'Other';
-          if (!byCategory[cat]) byCategory[cat] = [];
-          byCategory[cat].push(tag);
-        });
-        const categories = Object.keys(byCategory).sort();
-
-        let y = 0;
-        categories.forEach((cat) => {
-          virtualRows.push({ type: 'header', y, category: cat });
-          y += VLIST_HEADER_H;
-          byCategory[cat].forEach((tag) => {
-            virtualRows.push({
-              type: 'item',
-              y,
-              label: tag.label,
-              category: tag.category,
-            });
-            y += VLIST_ITEM_H;
+        // Search mode: flat results grouped by category (non-interactive
+        // headers), matching across the whole library.
+        if (tagSearchTerm) {
+          if (filteredTags.length === 0) return;
+          const byCategory = {};
+          filteredTags.forEach((tag) => {
+            const cat = tag.category || 'Other';
+            if (!byCategory[cat]) byCategory[cat] = [];
+            byCategory[cat].push(tag);
           });
+          const categories = Object.keys(byCategory).sort();
+          let y = 0;
+          categories.forEach((cat) => {
+            virtualRows.push({ type: 'header', y, category: cat });
+            y += VLIST_HEADER_H;
+            byCategory[cat].forEach((tag) => {
+              virtualRows.push({
+                type: 'item',
+                y,
+                label: tag.label,
+                category: tag.category,
+              });
+              y += VLIST_ITEM_H;
+            });
+            y += VLIST_SECTION_GAP;
+          });
+          virtualTotalHeight = y;
+          return;
+        }
+
+        // Browse mode: collapsible category headers. A category's tags are only
+        // emitted (and its height counted) once it's expanded.
+        let y = 0;
+        tagCategoriesList.forEach((cat) => {
+          const label = cat.label;
+          const isOpen = expandedCategories.has(label);
+          virtualRows.push({
+            type: 'header',
+            y,
+            category: label,
+            collapsible: true,
+            expanded: isOpen,
+          });
+          y += VLIST_HEADER_H;
+          if (isOpen) {
+            const tags = categoryTagsCache[label];
+            if (!tags) {
+              virtualRows.push({ type: 'loading', y, category: label });
+              y += VLIST_ITEM_H;
+            } else if (tags.length === 0) {
+              virtualRows.push({ type: 'loading', y, empty: true });
+              y += VLIST_ITEM_H;
+            } else {
+              tags.forEach((tag) => {
+                virtualRows.push({
+                  type: 'item',
+                  y,
+                  label: tag.label,
+                  category: tag.category,
+                });
+                y += VLIST_ITEM_H;
+              });
+            }
+          }
           y += VLIST_SECTION_GAP;
         });
         virtualTotalHeight = y;
@@ -2850,10 +3005,28 @@
         for (let i = firstIdx; i < lastIdx; i++) {
           const row = virtualRows[i];
           if (row.type === 'header') {
+            if (row.collapsible) {
+              // Browse-mode header: a chevron + click-to-expand affordance.
+              const chevron = row.expanded ? '▾' : '▸';
+              inner +=
+                `<div class="tag-category-header collapsible${
+                  row.expanded ? ' expanded' : ''
+                }" style="top:${row.y}px;" onclick="toggleCategory('${escapeAttr(
+                  row.category
+                )}')"><span class="tag-category-chevron">${chevron}</span><span>` +
+                escapeHtml(row.category) +
+                '</span></div>';
+            } else {
+              inner +=
+                `<div class="tag-category-header" style="top:${row.y}px;">` +
+                escapeHtml(row.category) +
+                '</div>';
+            }
+          } else if (row.type === 'loading') {
             inner +=
-              `<div class="tag-category-header" style="top:${row.y}px;">` +
-              escapeHtml(row.category) +
-              '</div>';
+              `<div class="tag-item tag-item-placeholder" style="top:${row.y}px;"><span>` +
+              (row.empty ? 'No tags in this category' : 'Loading…') +
+              '</span></div>';
           } else {
             const sel = selectedTags.has(row.label) ? ' selected' : '';
             inner +=
@@ -2887,12 +3060,13 @@
         virtualListenerInstalled = true;
       }
 
-      function renderTagList() {
+      function renderTagList(resetScroll = true) {
         ensureVirtualScrollListener();
         buildVirtualRows();
-        // Reset scroll on full rebuild (e.g. after filter change) so the
-        // user sees the top of the new result set.
-        tagList.scrollTop = 0;
+        // Reset scroll on a full rebuild (mode/filter change) so the user sees
+        // the top of the new result set. Expand/collapse passes false to keep
+        // the current scroll position.
+        if (resetScroll) tagList.scrollTop = 0;
         renderVirtualWindow();
       }
 
@@ -2949,17 +3123,28 @@
         applyFilter();
       }
 
-      function filterTagList(searchTerm) {
+      async function filterTagList(searchTerm) {
         const term = searchTerm.toLowerCase().trim();
+        tagSearchTerm = term;
         if (!term) {
-          filteredTags = [...allTags];
-        } else {
-          filteredTags = allTags.filter(
-            (tag) =>
-              tag.label.toLowerCase().includes(term) ||
-              (tag.category && tag.category.toLowerCase().includes(term))
-          );
+          // Back to browse mode (collapsed categories).
+          renderTagList();
+          return;
         }
+        // Search across the entire library. Load the full tag list once
+        // (lazily) so matches aren't limited to expanded categories.
+        if (!allTagsLoaded) {
+          tagList.innerHTML =
+            '<div class="tag-list-empty">Loading tags…</div>';
+          await loadAllTagsForSearch();
+          // The query may have changed while loading; bail if so.
+          if (tagSearchTerm !== term) return;
+        }
+        filteredTags = allTags.filter(
+          (tag) =>
+            tag.label.toLowerCase().includes(term) ||
+            (tag.category && tag.category.toLowerCase().includes(term))
+        );
         renderTagList();
       }
 
@@ -2967,7 +3152,8 @@
       document.getElementById('filterBtn').addEventListener('click', () => {
         filterModal.classList.add('show');
         tagSearch.value = ''; // Clear search input
-        loadAllTags();
+        tagSearchTerm = '';
+        loadCategories();
         renderSelectedTags();
         // Don't auto-focus search to avoid keyboard pop-up on mobile
       });
@@ -3024,6 +3210,7 @@
       window.toggleTag = toggleTag;
       window.removeTag = removeTag;
       window.clearAllTags = clearAllTags;
+      window.toggleCategory = toggleCategory;
 
       // Action buttons
       likeBtn.addEventListener('click', toggleLike);
@@ -3188,17 +3375,20 @@
         longPressIndicator.classList.remove('active');
       }
 
-      // Load tags for the menu (grouped by category)
+      // Load tags for the menu (grouped by category). Uses the full taxonomy
+      // tag list (not the capped typeahead) so nothing is cut off, and excludes
+      // the "Suggested" catch-all category.
       async function loadTagMenuData() {
         try {
-          const response = await fetch('/media/suggest?kind=tag&prefix=');
+          const response = await fetch('/api/taxonomy/tags');
           const data = await response.json();
-          const tags = data.tags || [];
+          const tags = data || [];
 
-          // Group by category
+          // Group by category, skipping the excluded category.
           const categoryMap = {};
-          tags.forEach(tag => {
+          tags.forEach((tag) => {
             const cat = tag.category || 'Other';
+            if (cat === EXCLUDED_CATEGORY) return;
             if (!categoryMap[cat]) {
               categoryMap[cat] = [];
             }

--- a/media-server/renderer/templates/swipe.go.html
+++ b/media-server/renderer/templates/swipe.go.html
@@ -249,14 +249,16 @@
         white-space: nowrap;
       }
 
-      /* Header toggles hide the description / tag overlays to maximise the
-         media area. Applied via body classes so already-rendered cards update
-         without a re-render. */
+      /* Display toggles (in the filter/settings panel) hide the tag and
+         description overlays to maximise the media area. Applied via body
+         classes so already-rendered cards update without a re-render. Hiding
+         the description also hides the filename path. */
       body.hide-swipe-tags .swipe-tags {
         display: none;
       }
 
-      body.hide-swipe-description .swipe-description {
+      body.hide-swipe-description .swipe-description,
+      body.hide-swipe-description .swipe-path {
         display: none;
       }
 
@@ -369,19 +371,6 @@
         background: rgba(255, 255, 255, 0.2);
       }
 
-      /* Right-aligned cluster of header actions (overlay toggles + filter) so
-         they stay together against the right edge, leaving the rest of the
-         header clear. */
-      .header-actions {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-      }
-
-      /* A toggle whose overlay is currently hidden reads as "off": dimmed. */
-      .header-btn.toggled-off {
-        opacity: 0.4;
-      }
 
       /* Filter button: dot indicator + count when a tag filter is active.
          A persisted filter from localStorage can otherwise silently produce
@@ -671,6 +660,41 @@
         font-size: 20px;
         font-weight: 600;
         color: var(--text);
+      }
+
+      /* Display toggles inside the settings/filter panel: hide tag chips or the
+         description+filename overlay to free up screen space. */
+      .display-toggles {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 16px;
+      }
+
+      .display-toggle {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 8px 14px;
+        border-radius: 20px;
+        background: rgba(0, 217, 165, 0.15);
+        border: 1px solid rgba(0, 217, 165, 0.3);
+        color: var(--accent);
+        font-size: 13px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.15s;
+      }
+
+      .display-toggle .display-toggle-icon {
+        font-size: 15px;
+        line-height: 1;
+      }
+
+      /* "off" state: the overlay is hidden, so the toggle reads as muted. */
+      .display-toggle.toggled-off {
+        background: rgba(255, 255, 255, 0.06);
+        border-color: rgba(255, 255, 255, 0.12);
+        color: var(--text-dim);
       }
 
       .filter-close {
@@ -1359,25 +1383,7 @@
       <div class="swipe-header">
         <a href="/media" class="header-btn" title="Back to browser">←</a>
         <span class="swipe-logo">Swipe</span>
-        <div class="header-actions">
-          <button
-            class="header-btn"
-            id="toggleTagsBtn"
-            title="Show/hide tags"
-            aria-pressed="true"
-          >
-            🏷️
-          </button>
-          <button
-            class="header-btn"
-            id="toggleDescBtn"
-            title="Show/hide description"
-            aria-pressed="true"
-          >
-            📝
-          </button>
-          <button class="header-btn" id="filterBtn" title="Filter">⚙</button>
-        </div>
+        <button class="header-btn" id="filterBtn" title="Filter">⚙</button>
       </div>
 
       <div class="progress-bar">
@@ -1445,6 +1451,29 @@
       <div class="filter-header">
         <span class="filter-title">Filter by Tags</span>
         <button class="filter-close" id="filterClose">✕</button>
+      </div>
+
+      <div class="display-toggles">
+        <button
+          type="button"
+          class="display-toggle"
+          id="toggleTagsBtn"
+          aria-pressed="true"
+          title="Show or hide tags on each item"
+        >
+          <span class="display-toggle-icon">🏷️</span>
+          <span>Tags</span>
+        </button>
+        <button
+          type="button"
+          class="display-toggle"
+          id="toggleDescBtn"
+          aria-pressed="true"
+          title="Show or hide the description and filename on each item"
+        >
+          <span class="display-toggle-icon">📝</span>
+          <span>Description</span>
+        </button>
       </div>
 
       <div class="selected-tags" id="selectedTags">

--- a/media-server/renderer/templates/swipe.go.html
+++ b/media-server/renderer/templates/swipe.go.html
@@ -249,6 +249,17 @@
         white-space: nowrap;
       }
 
+      /* Header toggles hide the description / tag overlays to maximise the
+         media area. Applied via body classes so already-rendered cards update
+         without a re-render. */
+      body.hide-swipe-tags .swipe-tags {
+        display: none;
+      }
+
+      body.hide-swipe-description .swipe-description {
+        display: none;
+      }
+
       /* Side actions */
       .swipe-actions {
         position: absolute;
@@ -356,6 +367,20 @@
 
       .header-btn:active {
         background: rgba(255, 255, 255, 0.2);
+      }
+
+      /* Right-aligned cluster of header actions (overlay toggles + filter) so
+         they stay together against the right edge, leaving the rest of the
+         header clear. */
+      .header-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      /* A toggle whose overlay is currently hidden reads as "off": dimmed. */
+      .header-btn.toggled-off {
+        opacity: 0.4;
       }
 
       /* Filter button: dot indicator + count when a tag filter is active.
@@ -1334,7 +1359,25 @@
       <div class="swipe-header">
         <a href="/media" class="header-btn" title="Back to browser">←</a>
         <span class="swipe-logo">Swipe</span>
-        <button class="header-btn" id="filterBtn" title="Filter">⚙</button>
+        <div class="header-actions">
+          <button
+            class="header-btn"
+            id="toggleTagsBtn"
+            title="Show/hide tags"
+            aria-pressed="true"
+          >
+            🏷️
+          </button>
+          <button
+            class="header-btn"
+            id="toggleDescBtn"
+            title="Show/hide description"
+            aria-pressed="true"
+          >
+            📝
+          </button>
+          <button class="header-btn" id="filterBtn" title="Filter">⚙</button>
+        </div>
       </div>
 
       <div class="progress-bar">
@@ -1658,9 +1701,56 @@
       let lastTouchCenter = { x: 0, y: 0 };
 
       // Initialize
+      // --- Overlay visibility toggles (tags / description) ---
+      // Header icon buttons hide the per-item tag chips and description so the
+      // media fills more of the screen. Persisted per-device in localStorage.
+      const HIDE_TAGS_KEY = 'swipe_hide_tags';
+      const HIDE_DESC_KEY = 'swipe_hide_description';
+
+      function applyOverlayVisibility() {
+        const hideTags = localStorage.getItem(HIDE_TAGS_KEY) === '1';
+        const hideDesc = localStorage.getItem(HIDE_DESC_KEY) === '1';
+        document.body.classList.toggle('hide-swipe-tags', hideTags);
+        document.body.classList.toggle('hide-swipe-description', hideDesc);
+        const tagsBtn = document.getElementById('toggleTagsBtn');
+        const descBtn = document.getElementById('toggleDescBtn');
+        if (tagsBtn) {
+          tagsBtn.classList.toggle('toggled-off', hideTags);
+          tagsBtn.setAttribute('aria-pressed', String(!hideTags));
+        }
+        if (descBtn) {
+          descBtn.classList.toggle('toggled-off', hideDesc);
+          descBtn.setAttribute('aria-pressed', String(!hideDesc));
+        }
+      }
+
+      function setupOverlayToggles() {
+        const tagsBtn = document.getElementById('toggleTagsBtn');
+        const descBtn = document.getElementById('toggleDescBtn');
+        if (tagsBtn) {
+          tagsBtn.addEventListener('click', () => {
+            const hidden = localStorage.getItem(HIDE_TAGS_KEY) === '1';
+            localStorage.setItem(HIDE_TAGS_KEY, hidden ? '0' : '1');
+            applyOverlayVisibility();
+          });
+        }
+        if (descBtn) {
+          descBtn.addEventListener('click', () => {
+            const hidden = localStorage.getItem(HIDE_DESC_KEY) === '1';
+            localStorage.setItem(HIDE_DESC_KEY, hidden ? '0' : '1');
+            applyOverlayVisibility();
+          });
+        }
+        applyOverlayVisibility();
+      }
+
       async function init() {
         // Do NOT restore saved position to ensure fresh start every time
         // const savedPath = getSavedPosition();
+
+        // Wire up the tag/description overlay toggles and apply the saved state
+        // before the first render so hidden overlays never flash in.
+        setupOverlayToggles();
 
         // Surface any persisted tag filter from localStorage immediately,
         // before the first fetch, so the user can see why an "empty" view

--- a/media-server/tasks/db_tags.go
+++ b/media-server/tasks/db_tags.go
@@ -82,13 +82,27 @@ func insertTagsForFile(db *sql.DB, filePath string, tags []TagInfo) error {
 	if err := EnsureTagsExist(db, tags); err != nil {
 		return err
 	}
-	stmt := `INSERT INTO media_tag_by_category (media_path, tag_label, category_label) VALUES (?, ?, ?)`
+	// time_stamp is the in-media offset, not a wall clock; 0 means "tags the
+	// media in general". Always write 0 here so auto-tagged rows match the 0
+	// convention used everywhere else (AddTag, createAssignment, etc.).
+	//
+	// INSERT OR IGNORE: a tag the file already carries collides with the
+	// (media_path, tag_label, category_label, time_stamp) primary key. Re-tagging
+	// a file (e.g. running the ONNX tagger again) must not abort the whole job on
+	// that collision — silently skip the pre-existing assignment and insert only
+	// the genuinely new tags.
+	stmt := `INSERT OR IGNORE INTO media_tag_by_category (media_path, tag_label, category_label, time_stamp) VALUES (?, ?, ?, 0)`
 	inserted := 0
 	for _, t := range tags {
-		if _, err := db.Exec(stmt, filePath, t.Label, t.Category); err != nil {
+		res, err := db.Exec(stmt, filePath, t.Label, t.Category)
+		if err != nil {
 			return fmt.Errorf("failed to insert tag %s/%s: %w", t.Category, t.Label, err)
 		}
-		inserted++
+		// RowsAffected is 0 when the row was an ignored duplicate, so this counts
+		// only tags actually added — keeping the cache invalidation below honest.
+		if n, err := res.RowsAffected(); err == nil {
+			inserted += int(n)
+		}
 	}
 	// New tag rows may make a previously-untagged path eligible for the
 	// swipe pool. Without this, auto-tagged paths never appear there until

--- a/media-server/tasks/db_tags_test.go
+++ b/media-server/tasks/db_tags_test.go
@@ -1,0 +1,94 @@
+package tasks
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// setupTagDB creates the minimal tag + media_tag_by_category schema that
+// insertTagsForFile touches, matching the real column/PK layout (the PK on
+// media_tag_by_category is what duplicate tags collide on).
+func setupTagDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if _, err := db.Exec(`CREATE TABLE tag (
+		label TEXT PRIMARY KEY,
+		category_label TEXT,
+		weight REAL,
+		preview TEXT,
+		thumbnail_path_600 TEXT
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE media_tag_by_category (
+		media_path TEXT,
+		tag_label TEXT,
+		category_label TEXT,
+		weight REAL,
+		time_stamp REAL,
+		created_at INTEGER,
+		PRIMARY KEY(media_path, tag_label, category_label, time_stamp)
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func countTagsForFile(t *testing.T, db *sql.DB, path string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM media_tag_by_category WHERE media_path = ?`, path,
+	).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+// Re-tagging a file that already carries some of the generated tags must not
+// fail: pre-existing assignments are silently skipped and only the new tags
+// are inserted.
+func TestInsertTagsForFile_SkipsExistingInsertsNew(t *testing.T) {
+	db := setupTagDB(t)
+	const path = "/media/a.jpg"
+
+	if err := insertTagsForFile(db, path, []TagInfo{
+		{Label: "sunset", Category: "Suggested"},
+	}); err != nil {
+		t.Fatalf("first insert failed: %v", err)
+	}
+	if got := countTagsForFile(t, db, path); got != 1 {
+		t.Fatalf("after first insert: got %d tags, want 1", got)
+	}
+
+	// Second run overlaps on "sunset" (the duplicate that previously aborted
+	// the whole job) and adds "beach".
+	if err := insertTagsForFile(db, path, []TagInfo{
+		{Label: "sunset", Category: "Suggested"},
+		{Label: "beach", Category: "Suggested"},
+	}); err != nil {
+		t.Fatalf("second insert (with a pre-existing tag) failed: %v", err)
+	}
+
+	if got := countTagsForFile(t, db, path); got != 2 {
+		t.Fatalf("after second insert: got %d tags, want 2 (sunset + beach)", got)
+	}
+
+	var hasBeach int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM media_tag_by_category WHERE media_path = ? AND tag_label = 'beach'`,
+		path,
+	).Scan(&hasBeach); err != nil {
+		t.Fatal(err)
+	}
+	if hasBeach != 1 {
+		t.Fatalf("expected the new 'beach' tag to be inserted, got %d", hasBeach)
+	}
+}

--- a/media-server/tasks/ingest_gallery.go
+++ b/media-server/tasks/ingest_gallery.go
@@ -34,23 +34,29 @@ func ingestGalleryTaskWithOptions(j *jobqueue.Job, q *jobqueue.Queue, mu *sync.M
 		return err
 	}
 
-	// Create staging directory for CLI tool output
-	stagingPath, err := stagingDir(j.ID)
+	// Resolve where gallery-dl writes: straight into the final local location
+	// (so it can detect and skip already-downloaded files) or a temp staging
+	// dir for S3 / no-backend setups.
+	target, err := resolveIngestDir(j.ID, "downloads/")
 	if err != nil {
-		q.PushJobStdout(j.ID, fmt.Sprintf("Error creating staging directory: %v", err))
+		q.PushJobStdout(j.ID, fmt.Sprintf("Error resolving download directory: %v", err))
 		q.ErrorJob(j.ID)
 		return err
 	}
-	defer cleanupStaging(stagingPath)
+	defer target.cleanup()
 
 	q.PushJobStdout(j.ID, fmt.Sprintf("Starting gallery-dl download: %s", url))
-	q.PushJobStdout(j.ID, fmt.Sprintf("Staging directory: %s", stagingPath))
+	if target.direct {
+		q.PushJobStdout(j.ID, fmt.Sprintf("Download directory (direct): %s", target.dir))
+	} else {
+		q.PushJobStdout(j.ID, fmt.Sprintf("Staging directory: %s", target.dir))
+	}
 
 	// Build gallery-dl arguments
 	// -d sets the base download directory
 	// --write-log outputs the downloaded file paths
 	args := []string{
-		"-d", stagingPath,
+		"-d", target.dir,
 		"--write-metadata",
 		url,
 	}
@@ -117,7 +123,7 @@ func ingestGalleryTaskWithOptions(j *jobqueue.Job, q *jobqueue.Queue, mu *sync.M
 
 			// gallery-dl outputs the file path for each downloaded file
 			// Check if the line looks like a valid file path
-			if line != "" && isDownloadedFilePath(line, stagingPath) {
+			if line != "" && isDownloadedFilePath(line, target.dir) {
 				mu.Lock()
 				downloadedFiles = append(downloadedFiles, line)
 				mu.Unlock()
@@ -180,13 +186,19 @@ func ingestGalleryTaskWithOptions(j *jobqueue.Job, q *jobqueue.Queue, mu *sync.M
 		}
 	}
 
-	// Upload staged files to the default storage backend
-	finalFiles := uploadStagedFiles(ctx, q, j.ID, downloadedFiles, stagingPath, "downloads/")
+	// In direct mode the downloaded paths are already final; otherwise upload
+	// the staged files (and their sidecars) to the default storage backend.
+	var finalFiles []string
+	if target.direct {
+		finalFiles = downloadedFiles
+	} else {
+		finalFiles = uploadStagedFiles(ctx, q, j.ID, downloadedFiles, target.dir, "downloads/")
 
-	// Upload metadata sidecars to the same destination so they sit next to
-	// the media. Not inserted into the media table — they are sidecars only.
-	if len(metadataFiles) > 0 {
-		uploadStagedFiles(ctx, q, j.ID, metadataFiles, stagingPath, "downloads/")
+		// Upload metadata sidecars to the same destination so they sit next to
+		// the media. Not inserted into the media table — they are sidecars only.
+		if len(metadataFiles) > 0 {
+			uploadStagedFiles(ctx, q, j.ID, metadataFiles, target.dir, "downloads/")
+		}
 	}
 
 	// Add final files to database
@@ -214,7 +226,12 @@ func ingestGalleryTaskWithOptions(j *jobqueue.Job, q *jobqueue.Queue, mu *sync.M
 		}
 		finalToSidecar := make(map[string]string)
 		for _, mediaStaging := range downloadedFiles {
-			predictedFinal := stagedToFinalPath(mediaStaging, stagingPath, "downloads/")
+			// In direct mode the downloaded path is already final; otherwise
+			// predict where the staged file landed in the backend.
+			predictedFinal := mediaStaging
+			if !target.direct {
+				predictedFinal = stagedToFinalPath(mediaStaging, target.dir, "downloads/")
+			}
 			if _, ok := insertedSet[predictedFinal]; !ok {
 				continue
 			}
@@ -247,6 +264,13 @@ func ingestGalleryTaskWithOptions(j *jobqueue.Job, q *jobqueue.Queue, mu *sync.M
 // isDownloadedFilePath checks if a line looks like a downloaded file path
 // gallery-dl outputs the path of each written file to stdout
 func isDownloadedFilePath(line string, downloadPath string) bool {
+	// gallery-dl prefixes a path with '#' when the file already exists and is
+	// being skipped (not re-downloaded). These are not new files, so they must
+	// not be ingested.
+	if strings.HasPrefix(line, "#") {
+		return false
+	}
+
 	// Check if it's an absolute path or starts with download path
 	if filepath.IsAbs(line) {
 		// Verify it's a media file
@@ -266,12 +290,10 @@ func isDownloadedFilePath(line string, downloadPath string) bool {
 		}
 	}
 
-	// Check if line contains the download path
+	// Check if line contains the download path ('#'-prefixed skip lines are
+	// already rejected above).
 	if strings.Contains(line, downloadPath) {
-		// Extract the path portion if it's a log line
-		// gallery-dl format might be like: "# path/to/file.jpg" or just "path/to/file.jpg"
-		cleanLine := strings.TrimPrefix(line, "# ")
-		if isMediaFile(cleanLine) {
+		if isMediaFile(line) {
 			return true
 		}
 	}

--- a/media-server/tasks/ingest_gallery_test.go
+++ b/media-server/tasks/ingest_gallery_test.go
@@ -1,0 +1,30 @@
+package tasks
+
+import "testing"
+
+// gallery-dl prints a destination path for each file. When a file already
+// exists and is being skipped it prefixes the path with '#'. Those skip lines
+// must NOT be treated as freshly downloaded files (and so must not be ingested).
+func TestIsDownloadedFilePath(t *testing.T) {
+	const dir = "/downloads/site"
+
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"freshly written media", "/downloads/site/photo.jpg", true},
+		{"skipped (already exists) with space", "# /downloads/site/photo.jpg", false},
+		{"skipped (already exists) no space", "#/downloads/site/photo.jpg", false},
+		{"metadata sidecar is not media", "/downloads/site/photo.jpg.json", false},
+		{"blank line", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isDownloadedFilePath(tc.line, dir); got != tc.want {
+				t.Errorf("isDownloadedFilePath(%q) = %v, want %v", tc.line, got, tc.want)
+			}
+		})
+	}
+}

--- a/media-server/tasks/ingest_youtube.go
+++ b/media-server/tasks/ingest_youtube.go
@@ -33,21 +33,27 @@ func ingestYouTubeTaskWithOptions(j *jobqueue.Job, q *jobqueue.Queue, mu *sync.M
 		return err
 	}
 
-	// Create staging directory for CLI tool output
-	stagingPath, err := stagingDir(j.ID)
+	// Resolve where yt-dlp writes: straight into the final local location (so it
+	// can detect and skip already-downloaded files) or a temp staging dir for
+	// S3 / no-backend setups.
+	target, err := resolveIngestDir(j.ID, "downloads/")
 	if err != nil {
-		q.PushJobStdout(j.ID, fmt.Sprintf("Error creating staging directory: %v", err))
+		q.PushJobStdout(j.ID, fmt.Sprintf("Error resolving download directory: %v", err))
 		q.ErrorJob(j.ID)
 		return err
 	}
-	defer cleanupStaging(stagingPath)
+	defer target.cleanup()
 
 	q.PushJobStdout(j.ID, fmt.Sprintf("Starting YouTube download: %s", url))
-	q.PushJobStdout(j.ID, fmt.Sprintf("Staging directory: %s", stagingPath))
+	if target.direct {
+		q.PushJobStdout(j.ID, fmt.Sprintf("Download directory (direct): %s", target.dir))
+	} else {
+		q.PushJobStdout(j.ID, fmt.Sprintf("Staging directory: %s", target.dir))
+	}
 
 	// Build yt-dlp arguments
 	// Use --print to get the final filename after download
-	outputTemplate := filepath.Join(stagingPath, "%(title)s [%(id)s].%(ext)s")
+	outputTemplate := filepath.Join(target.dir, "%(title)s [%(id)s].%(ext)s")
 	args := []string{
 		"-o", outputTemplate,
 		"--print", "after_move:filepath", // Print the final file path after download
@@ -161,8 +167,14 @@ func ingestYouTubeTaskWithOptions(j *jobqueue.Job, q *jobqueue.Queue, mu *sync.M
 		return err
 	}
 
-	// Upload staged files to the default storage backend
-	finalFiles := uploadStagedFiles(ctx, q, j.ID, downloadedFiles, stagingPath, "downloads/")
+	// In direct mode the downloaded paths are already final; otherwise upload
+	// the staged files to the default storage backend.
+	var finalFiles []string
+	if target.direct {
+		finalFiles = downloadedFiles
+	} else {
+		finalFiles = uploadStagedFiles(ctx, q, j.ID, downloadedFiles, target.dir, "downloads/")
+	}
 
 	// Add final files to database
 	var insertedFiles []string

--- a/media-server/tasks/llm_vision.go
+++ b/media-server/tasks/llm_vision.go
@@ -7,7 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"image"
+	"image/color"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -113,13 +116,12 @@ func callVisionLLM(ctx context.Context, imagePath, prompt string) (string, error
 // {input: ...} envelope and supports async /run polling. If we ever pick up
 // more OpenAI-shaped providers (vLLM, TGI, etc.) they reuse this helper.
 func callOpenAICompatibleVision(ctx context.Context, imagePath, prompt, baseURL, apiKey, model string) (string, error) {
-	data, err := os.ReadFile(imagePath)
+	img, err := loadImageForInference(imagePath)
 	if err != nil {
-		return "", fmt.Errorf("could not read image for inference: %w", err)
+		return "", fmt.Errorf("inference: %w", err)
 	}
-	b64 := base64.StdEncoding.EncodeToString(data)
-	mime := mimeFromExt(imagePath)
-	dataURI := fmt.Sprintf("data:%s;base64,%s", mime, b64)
+	endpoint := strings.TrimRight(baseURL, "/") + "/v1/chat/completions"
+	img.logRequest("openai-compatible", model, endpoint, prompt)
 
 	payload := map[string]any{
 		"model":  model,
@@ -129,7 +131,7 @@ func callOpenAICompatibleVision(ctx context.Context, imagePath, prompt, baseURL,
 				"role": "user",
 				"content": []map[string]any{
 					{"type": "text", "text": prompt},
-					{"type": "image_url", "image_url": map[string]any{"url": dataURI}},
+					{"type": "image_url", "image_url": map[string]any{"url": img.dataURI()}},
 				},
 			},
 		},
@@ -139,7 +141,6 @@ func callOpenAICompatibleVision(ctx context.Context, imagePath, prompt, baseURL,
 		return "", fmt.Errorf("failed to marshal chat-completions payload: %w", err)
 	}
 
-	endpoint := strings.TrimRight(baseURL, "/") + "/v1/chat/completions"
 	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(body))
 	if err != nil {
 		return "", fmt.Errorf("failed to build request: %w", err)
@@ -183,6 +184,7 @@ func callOpenAICompatibleVision(ctx context.Context, imagePath, prompt, baseURL,
 		return "", fmt.Errorf("inference response missing choices: %s", string(rawBody))
 	}
 	content := strings.TrimSpace(parsed.Choices[0].Message.Content)
+	logVisionResponse("openai-compatible", len(rawBody), content)
 	if content == "" {
 		return "", fmt.Errorf("inference response empty content: %s", string(rawBody))
 	}
@@ -193,14 +195,14 @@ func callOpenAICompatibleVision(ctx context.Context, imagePath, prompt, baseURL,
 // Ollama server and returns the model's response field. Equivalent to the
 // in-line plumbing that used to live in metadata_ops.go and autotag_vision.go.
 func callOllamaVisionRaw(ctx context.Context, imagePath, prompt, baseURL, model string) (string, error) {
-	data, err := os.ReadFile(imagePath)
+	img, err := loadImageForInference(imagePath)
 	if err != nil {
-		return "", fmt.Errorf("could not read image for Ollama: %w", err)
+		return "", fmt.Errorf("ollama: %w", err)
 	}
-	b64 := base64.StdEncoding.EncodeToString(data)
-	reqJSON := fmt.Sprintf(`{"model":"%s","stream":false,"prompt":%s,"images":["%s"]}`,
-		model, strconv.Quote(prompt), b64)
 	base := strings.TrimRight(baseURL, "/")
+	img.logRequest("ollama", model, base+"/api/generate", prompt)
+	reqJSON := fmt.Sprintf(`{"model":"%s","stream":false,"prompt":%s,"images":["%s"]}`,
+		model, strconv.Quote(prompt), img.base64())
 	req, err := http.NewRequestWithContext(ctx, "POST", base+"/api/generate", strings.NewReader(reqJSON))
 	if err != nil {
 		return "", fmt.Errorf("failed to build request: %w", err)
@@ -225,6 +227,7 @@ func callOllamaVisionRaw(ctx context.Context, imagePath, prompt, baseURL, model 
 	if err := json.Unmarshal(respData, &response); err != nil {
 		return "", fmt.Errorf("could not unmarshal Ollama response: %w", err)
 	}
+	logVisionResponse("ollama", len(respData), strings.TrimSpace(response.Response))
 	return response.Response, nil
 }
 
@@ -238,13 +241,11 @@ var runPodAsyncEndpoint = regexp.MustCompile(`/run(?:\/?$|\?)`)
 // the model's text response. Mirrors the structure tested in
 // thespian/send-image.js.
 func callRunPodVision(ctx context.Context, imagePath, prompt, endpoint, apiKey string) (string, error) {
-	data, err := os.ReadFile(imagePath)
+	img, err := loadImageForInference(imagePath)
 	if err != nil {
-		return "", fmt.Errorf("could not read image for RunPod: %w", err)
+		return "", fmt.Errorf("runpod: %w", err)
 	}
-	b64 := base64.StdEncoding.EncodeToString(data)
-	mime := mimeFromExt(imagePath)
-	dataURI := fmt.Sprintf("data:%s;base64,%s", mime, b64)
+	img.logRequest("runpod", "", endpoint, prompt)
 
 	payload := map[string]any{
 		"input": map[string]any{
@@ -253,7 +254,7 @@ func callRunPodVision(ctx context.Context, imagePath, prompt, endpoint, apiKey s
 					"role": "user",
 					"content": []map[string]any{
 						{"type": "text", "text": prompt},
-						{"type": "image_url", "image_url": map[string]any{"url": dataURI}},
+						{"type": "image_url", "image_url": map[string]any{"url": img.dataURI()}},
 					},
 				},
 			},
@@ -306,6 +307,7 @@ func callRunPodVision(ctx context.Context, imagePath, prompt, endpoint, apiKey s
 		return "", fmt.Errorf("RunPod job %s (id=%s)", final.Status, final.ID)
 	}
 	text := extractRunPodText(final)
+	logVisionResponse("runpod", len(rawBody), text)
 	if text == "" {
 		// Surface the raw body so a misshaped worker response is debuggable.
 		return "", fmt.Errorf("RunPod response missing text output: %s", string(rawBody))
@@ -398,6 +400,177 @@ func extractRunPodText(r runPodResponse) string {
 		}
 	}
 	return ""
+}
+
+// imagePayload is the validated, instrumented image we hand to a vision
+// backend. It exists so every provider (Ollama, OpenAI-compatible, RunPod)
+// loads bytes the same way, logs the same diagnostics, and labels the MIME
+// type consistently — the three used to each call os.ReadFile + mimeFromExt
+// inline with no logging, which is why a "the model acted like it never got
+// an image" run left nothing to inspect.
+type imagePayload struct {
+	path        string
+	data        []byte
+	extMime     string // MIME guessed from the file extension (mimeFromExt)
+	sniffedMime string // MIME sniffed from the first bytes (http.DetectContentType)
+	format      string // decoded format ("png","jpeg","webp",…); "" if undecodable
+	colorModel  string // decoded color model ("ycbcr","cmyk","rgba",…); "" if undecodable
+	width       int
+	height      int
+}
+
+// colorModelName maps a decoded color.Model to a short label. CMYK is the one
+// worth watching for in JPEGs: Go decodes it fine, but the stb_image-based
+// decoders in several local vision backends mishandle CMYK JPEGs and hand the
+// model a blank/garbage frame — a plausible cause of "the model answered as if
+// it never saw the (jpg) image" that leaves no error behind.
+func colorModelName(m color.Model) string {
+	switch m {
+	case color.YCbCrModel:
+		return "ycbcr"
+	case color.CMYKModel:
+		return "cmyk"
+	case color.RGBAModel:
+		return "rgba"
+	case color.NRGBAModel:
+		return "nrgba"
+	case color.GrayModel:
+		return "gray"
+	case color.Gray16Model:
+		return "gray16"
+	default:
+		return "other"
+	}
+}
+
+// loadImageForInference reads the image, validates it is non-empty, sniffs its
+// real content type, and best-effort decodes its header for the true format +
+// dimensions. A decode failure is NOT fatal (the backend may still accept the
+// raw bytes) but it is a loud signal in the logs. The decoders for
+// png/jpeg/gif/webp/bmp/tiff are registered package-wide via the blank imports
+// in metadata_ops.go, so DecodeConfig here understands every format the
+// describe path can produce.
+func loadImageForInference(imagePath string) (*imagePayload, error) {
+	data, err := os.ReadFile(imagePath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read image %q: %w", imagePath, err)
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("image %q is empty (0 bytes) — nothing to send to the model", imagePath)
+	}
+	p := &imagePayload{
+		path:        imagePath,
+		data:        data,
+		extMime:     mimeFromExt(imagePath),
+		sniffedMime: http.DetectContentType(data),
+	}
+	if cfg, format, derr := image.DecodeConfig(bytes.NewReader(data)); derr == nil {
+		p.format, p.width, p.height = format, cfg.Width, cfg.Height
+		p.colorModel = colorModelName(cfg.ColorModel)
+	}
+	return p, nil
+}
+
+// bestMime prefers the type sniffed from the actual bytes over the one guessed
+// from the extension — this fixes mislabeled files and the
+// application/octet-stream fallback. When the sniff can't recognize the bytes
+// as an image (e.g. avif/heic, which http.DetectContentType doesn't know) it
+// falls back to the extension-derived MIME so behavior is never worse than
+// before.
+func (p *imagePayload) bestMime() string {
+	if strings.HasPrefix(p.sniffedMime, "image/") {
+		return p.sniffedMime
+	}
+	return p.extMime
+}
+
+func (p *imagePayload) base64() string {
+	return base64.StdEncoding.EncodeToString(p.data)
+}
+
+func (p *imagePayload) dataURI() string {
+	return fmt.Sprintf("data:%s;base64,%s", p.bestMime(), p.base64())
+}
+
+// logRequest emits a single line confirming exactly what is about to leave for
+// the model: byte count, encoded length, the MIME we attached (and whether the
+// extension disagreed), the decoded format/dimensions, and the prompt length.
+// "decoded=UNDECODABLE" means no registered decoder could read the bytes — a
+// strong hint the backend won't be able to either.
+func (p *imagePayload) logRequest(provider, model, endpoint, prompt string) {
+	decoded := "UNDECODABLE(no registered decoder matched the bytes)"
+	if p.format != "" {
+		decoded = fmt.Sprintf("%s/%s %dx%d", p.format, p.colorModel, p.width, p.height)
+	}
+	mimeNote := p.bestMime()
+	if p.bestMime() != p.extMime {
+		mimeNote = fmt.Sprintf("%s (extension implied %s)", p.bestMime(), p.extMime)
+	}
+	log.Printf("[vision:request] provider=%s model=%q endpoint=%q file=%q bytes=%d base64Len=%d mime=%s decoded=%s promptLen=%d",
+		provider, model, endpoint, filepath.Base(p.path), len(p.data),
+		base64.StdEncoding.EncodedLen(len(p.data)), mimeNote, decoded, len(prompt))
+}
+
+// logVisionResponse records what came back so a blind-but-successful run is
+// distinguishable from a healthy one: the raw HTTP body size, the extracted
+// content length, and a short preview (which surfaces "I don't see an image"
+// style refusals without dumping a whole description into the log).
+func logVisionResponse(provider string, rawLen int, content string) {
+	preview := strings.ReplaceAll(content, "\n", " ")
+	if len(preview) > 200 {
+		preview = preview[:200] + "…"
+	}
+	log.Printf("[vision:response] provider=%s rawBytes=%d contentLen=%d preview=%q",
+		provider, rawLen, len(content), preview)
+}
+
+// noImageResponseMarkers are first-person phrases a vision model emits when it
+// got the prompt but no image — i.e. the backend never handed the image to the
+// model (a non-vision model, or a preprocessor that dropped it, e.g. on an
+// extreme aspect ratio). They are deliberately phrased from the model's "I
+// wasn't given an image" perspective so they don't match descriptions that
+// merely mention images ("a sign that reads no photography").
+var noImageResponseMarkers = []string{
+	"no image was provided",
+	"no image provided",
+	"since no image",
+	"cannot see an image",
+	"can't see an image",
+	"cannot see any image",
+	"can't see any image",
+	"don't see an image",
+	"do not see an image",
+	"don't see any image",
+	"do not see any image",
+	"unable to view the image",
+	"unable to see the image",
+	"unable to view an image",
+	"haven't provided an image",
+	"have not provided an image",
+	"didn't provide an image",
+	"did not provide an image",
+	"wasn't provided an image",
+	"was not provided an image",
+	"wasn't provided with an image",
+	"was not provided with an image",
+	"didn't receive an image",
+	"did not receive an image",
+	"no image attached",
+	"no image was attached",
+}
+
+// looksLikeNoImageResponse reports whether content matches a known "I didn't
+// get an image" pattern. Heuristic by design: it gates saving an obviously
+// blind description, it does not judge correctness. Callers treat a hit as a
+// failure so the bad text is never persisted to the library.
+func looksLikeNoImageResponse(content string) bool {
+	lc := strings.ToLower(content)
+	for _, m := range noImageResponseMarkers {
+		if strings.Contains(lc, m) {
+			return true
+		}
+	}
+	return false
 }
 
 func mimeFromExt(path string) string {

--- a/media-server/tasks/lora_dataset.go
+++ b/media-server/tasks/lora_dataset.go
@@ -207,7 +207,7 @@ func getOrGenerateDescription(ctx context.Context, db *sql.DB, filePath string, 
 	}
 
 	// Generate description using Ollama
-	generatedDesc, err := describeFileWithOllama(ctx, filePath, model, "")
+	generatedDesc, err := describeFileWithOllama(ctx, nil, "", filePath, model, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to generate description: %w", err)
 	}

--- a/media-server/tasks/metadata_ops.go
+++ b/media-server/tasks/metadata_ops.go
@@ -66,7 +66,7 @@ func generateDescriptions(ctx context.Context, q *jobqueue.Queue, jobID string, 
 			return ctx.Err()
 		default:
 		}
-		description, err := describeFileWithOllama(ctx, filePath, model, "")
+		description, err := describeFileWithOllama(ctx, q, jobID, filePath, model, "")
 		if err != nil {
 			q.PushJobStdout(jobID, fmt.Sprintf("Warning: failed to describe %s: %v", filePath, err))
 			continue
@@ -438,10 +438,11 @@ func getVideoMetadata(ctx context.Context, videoPath string) (duration float64, 
 	return duration, frameCount, nil
 }
 
-func describeFileWithOllama(ctx context.Context, mediaPath, model, customPrompt string) (string, error) {
+func describeFileWithOllama(ctx context.Context, q *jobqueue.Queue, jobID, mediaPath, model, customPrompt string) (string, error) {
 	ext := strings.ToLower(filepath.Ext(mediaPath))
 	var tempImagePath string
 	var cleanupPaths []string
+	source := "image"
 	if ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".bmp" || ext == ".webp" {
 		tempImagePath = mediaPath
 	} else {
@@ -451,6 +452,7 @@ func describeFileWithOllama(ctx context.Context, mediaPath, model, customPrompt 
 		}
 		cleanupPaths = append(cleanupPaths, screenshotPath)
 		tempImagePath = screenshotPath
+		source = "video-frame:" + filepath.Base(screenshotPath)
 	}
 	resizedPath, err := resizeImageIfNeeded(tempImagePath)
 	if err != nil {
@@ -462,6 +464,7 @@ func describeFileWithOllama(ctx context.Context, mediaPath, model, customPrompt 
 	if resizedPath != tempImagePath {
 		cleanupPaths = append(cleanupPaths, resizedPath)
 	}
+	logImageParseToJob(q, jobID, mediaPath, source, tempImagePath, resizedPath)
 	description, err := callOllamaVision(ctx, resizedPath, model, customPrompt)
 	if err != nil {
 		for _, p := range cleanupPaths {
@@ -472,13 +475,62 @@ func describeFileWithOllama(ctx context.Context, mediaPath, model, customPrompt 
 	for _, p := range cleanupPaths {
 		_ = os.Remove(p)
 	}
+	// Guard against a "blind" reply: the backend returned 200 with prose, but
+	// the prose says it never got an image. Treat it as a failure so this text
+	// is not persisted as the file's description — a silent save here is how the
+	// bug hid for so long. No retry (caller decides); the job log shows it.
+	if looksLikeNoImageResponse(description) {
+		preview := strings.ReplaceAll(description, "\n", " ")
+		if len(preview) > 160 {
+			preview = preview[:160] + "…"
+		}
+		return "", fmt.Errorf("model returned a no-image response (image was not ingested by the backend): %q", preview)
+	}
 	return description, nil
 }
 
-// resizeImageIfNeeded ensures the image fed to Ollama has its long side at
-// most maxLongSide pixels. Returns the original path unchanged if it already
-// fits, otherwise writes a downscaled PNG to a uniquely-named temp file and
-// returns that path; caller is responsible for removing it.
+// logImageParseToJob pushes one line into the per-job stdout (visible in the
+// Jobs UI) confirming the image was located, decoded, and what is about to be
+// handed to the vision backend. A healthy run and a "model went in blind" run
+// previously produced identical job logs ("description: generated"); this line
+// makes the difference inspectable: the true decoded format/dimensions, whether
+// the file was resized/re-encoded, and the byte count actually sent. Pair it
+// with the [vision:request]/[vision:response] lines in the server log.
+func logImageParseToJob(q *jobqueue.Queue, jobID, originalPath, source, framePath, sentPath string) {
+	if q == nil {
+		return
+	}
+	var sentBytes int64
+	if info, err := os.Stat(sentPath); err == nil {
+		sentBytes = info.Size()
+	}
+	format, cm, w, h := "UNDECODABLE", "", 0, 0
+	if f, err := os.Open(sentPath); err == nil {
+		if cfg, fm, derr := image.DecodeConfig(f); derr == nil {
+			format, cm, w, h = fm, colorModelName(cfg.ColorModel), cfg.Width, cfg.Height
+		}
+		_ = f.Close()
+	}
+	normalized := "no"
+	if sentPath != framePath {
+		normalized = "yes→" + filepath.Base(sentPath)
+	}
+	q.PushJobStdout(jobID, fmt.Sprintf(
+		"  image: %s | source=%s | decoded=%s/%s %dx%d | normalized=%s | bytesSent=%d",
+		filepath.Base(originalPath), source, format, cm, w, h, normalized, sentBytes))
+}
+
+// resizeImageIfNeeded normalizes an image for a vision backend: it guarantees
+// the bytes handed to the model are in a universally-decodable format (PNG) and
+// no larger than maxLongSide on the long edge.
+//
+// The original path is returned unchanged ONLY when the source is already a
+// model-safe format (JPEG/PNG) AND within size. Anything else — webp, bmp,
+// gif, tiff — is re-encoded to a PNG temp file even when it doesn't need
+// resizing, so every backend gets a format it can decode.
+//
+// The caller is responsible for removing any returned temp file (it differs
+// from the input path exactly when re-encoding happened).
 func resizeImageIfNeeded(path string) (string, error) {
 	const maxLongSide = 1280
 
@@ -487,7 +539,7 @@ func resizeImageIfNeeded(path string) (string, error) {
 		return "", err
 	}
 	defer f.Close()
-	img, _, err := image.Decode(f)
+	img, format, err := image.Decode(f)
 	if err != nil {
 		return "", fmt.Errorf("image decode failed: %w", err)
 	}
@@ -496,21 +548,30 @@ func resizeImageIfNeeded(path string) (string, error) {
 	if b.Dy() > longSide {
 		longSide = b.Dy()
 	}
-	if longSide <= maxLongSide {
+
+	// JPEG and PNG are accepted by every vision backend we target; leave them
+	// untouched when they also fit the size budget. Every other decoded format
+	// is normalized below.
+	safeFormat := format == "jpeg" || format == "png"
+	if safeFormat && longSide <= maxLongSide {
 		return path, nil
 	}
 
-	scale := float64(maxLongSide) / float64(longSide)
-	w := int(float64(b.Dx()) * scale)
-	h := int(float64(b.Dy()) * scale)
-	if w < 1 {
-		w = 1
+	dst := img
+	if longSide > maxLongSide {
+		scale := float64(maxLongSide) / float64(longSide)
+		w := int(float64(b.Dx()) * scale)
+		h := int(float64(b.Dy()) * scale)
+		if w < 1 {
+			w = 1
+		}
+		if h < 1 {
+			h = 1
+		}
+		resized := image.NewRGBA(image.Rect(0, 0, w, h))
+		xdraw.CatmullRom.Scale(resized, resized.Bounds(), img, b, xdraw.Over, nil)
+		dst = resized
 	}
-	if h < 1 {
-		h = 1
-	}
-	dst := image.NewRGBA(image.Rect(0, 0, w, h))
-	xdraw.CatmullRom.Scale(dst, dst.Bounds(), img, b, xdraw.Over, nil)
 
 	out, err := os.CreateTemp("", "ollama_resize_*.png")
 	if err != nil {
@@ -757,7 +818,7 @@ func processDescriptionForFile(ctx context.Context, q *jobqueue.Queue, jobID str
 		}
 	}
 
-	description, err := describeFileWithOllama(ctx, filePath, model, customPrompt)
+	description, err := describeFileWithOllama(ctx, q, jobID, filePath, model, customPrompt)
 	if err != nil {
 		return fmt.Errorf("failed to describe: %w", err)
 	}

--- a/media-server/tasks/metadata_ops_test.go
+++ b/media-server/tasks/metadata_ops_test.go
@@ -1,10 +1,124 @@
 package tasks
 
 import (
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"golang.org/x/image/bmp"
 
 	"github.com/stevecastle/shrike/appconfig"
 )
+
+// writeTestImage renders a solid w×h image and encodes it with enc into a temp
+// file with the given name, returning its path.
+func writeTestImage(t *testing.T, name string, w, h int, enc func(io.Writer, image.Image) error) string {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: 10, G: 120, B: 200, A: 255})
+		}
+	}
+	path := filepath.Join(t.TempDir(), name)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", path, err)
+	}
+	if err := enc(f, img); err != nil {
+		_ = f.Close()
+		t.Fatalf("encode %s: %v", path, err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close %s: %v", path, err)
+	}
+	return path
+}
+
+// decodedImage opens path and returns the registered decoder name + dimensions.
+func decodedImage(t *testing.T, path string) (format string, w, h int) {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	cfg, format, err := image.DecodeConfig(f)
+	if err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	return format, cfg.Width, cfg.Height
+}
+
+// A small JPEG/PNG is already model-safe and within size, so it must pass
+// through untouched (same path, no temp file).
+func TestResizeImageIfNeededPassesThroughSmallPNG(t *testing.T) {
+	src := writeTestImage(t, "small.png", 100, 80, png.Encode)
+	got, err := resizeImageIfNeeded(src)
+	if err != nil {
+		t.Fatalf("resizeImageIfNeeded: %v", err)
+	}
+	if got != src {
+		t.Fatalf("expected passthrough (same path), got %q", got)
+	}
+}
+
+// The regression guard: a SMALL bmp/webp/etc. used to slip through in its
+// original format. It must now be re-encoded to a PNG temp file even though it
+// needs no resizing — otherwise backends that can't decode it answer blind.
+func TestResizeImageIfNeededNormalizesSmallNonSafeFormat(t *testing.T) {
+	src := writeTestImage(t, "small.bmp", 100, 80, bmp.Encode)
+	got, err := resizeImageIfNeeded(src)
+	if err != nil {
+		t.Fatalf("resizeImageIfNeeded: %v", err)
+	}
+	if got == src {
+		t.Fatal("expected a re-encoded temp file, got the original bmp path back")
+	}
+	t.Cleanup(func() { _ = os.Remove(got) })
+	if format, _, _ := decodedImage(t, got); format != "png" {
+		t.Fatalf("expected normalized output to be png, got %q", format)
+	}
+}
+
+// Oversized images are still downscaled (and emitted as PNG) as before.
+func TestResizeImageIfNeededResizesOversized(t *testing.T) {
+	src := writeTestImage(t, "big.png", 2000, 1000, png.Encode)
+	got, err := resizeImageIfNeeded(src)
+	if err != nil {
+		t.Fatalf("resizeImageIfNeeded: %v", err)
+	}
+	if got == src {
+		t.Fatal("expected a resized temp file for an oversized image")
+	}
+	t.Cleanup(func() { _ = os.Remove(got) })
+	format, w, h := decodedImage(t, got)
+	if format != "png" {
+		t.Fatalf("expected png output, got %q", format)
+	}
+	long := w
+	if h > w {
+		long = h
+	}
+	if long != 1280 {
+		t.Fatalf("expected long side clamped to 1280, got %dx%d", w, h)
+	}
+}
+
+func TestLooksLikeNoImageResponse(t *testing.T) {
+	blind := "Since no image was provided in your prompt (only the instructions), I cannot generate specific research notes."
+	if !looksLikeNoImageResponse(blind) {
+		t.Fatal("expected the blind response to be detected")
+	}
+	legit := "A white-haired woman in a green cloak stands in a sunlit field; a small wooden sign is visible at the lower left."
+	if looksLikeNoImageResponse(legit) {
+		t.Fatal("false positive on a legitimate description")
+	}
+}
 
 func TestResolveDescribePromptUsesCustomWhenProvided(t *testing.T) {
 	got := resolveDescribePrompt("custom override")

--- a/media-server/tasks/staging.go
+++ b/media-server/tasks/staging.go
@@ -25,6 +25,46 @@ func stagingDir(jobID string) (string, error) {
 	return dir, nil
 }
 
+// ingestTarget describes where a CLI download tool (gallery-dl, yt-dlp) writes
+// files for an ingest job, and how to finalize them afterwards.
+type ingestTarget struct {
+	// dir is the directory handed to the CLI tool (gallery-dl -d / yt-dlp -o).
+	dir string
+	// direct is true when dir is the final on-disk location (local backend):
+	// downloaded files need no upload step and their absolute paths are already
+	// the paths to persist. When false, dir is a temp staging dir whose contents
+	// must be uploaded via uploadStagedFiles.
+	direct bool
+	// cleanup removes the staging dir; a no-op in direct mode.
+	cleanup func()
+}
+
+// resolveIngestDir decides whether an ingest job downloads straight into its
+// final local location or into a temporary staging dir.
+//
+// When the default backend is local, the CLI tool writes directly into
+// <root>/<destPrefix>. Downloading into the real destination lets gallery-dl /
+// yt-dlp see previously-downloaded files and skip them — which a fresh per-job
+// staging dir would defeat. For S3, or when no backend is configured, we fall
+// back to staging + upload (unchanged behavior).
+func resolveIngestDir(jobID, destPrefix string) (ingestTarget, error) {
+	if backend := defaultBackend(); backend != nil {
+		if root := backend.Root(); root.Type == "local" {
+			dir := filepath.Join(root.Path, filepath.FromSlash(strings.Trim(destPrefix, "/")))
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				return ingestTarget{}, fmt.Errorf("create download dir: %w", err)
+			}
+			return ingestTarget{dir: dir, direct: true, cleanup: func() {}}, nil
+		}
+	}
+
+	dir, err := stagingDir(jobID)
+	if err != nil {
+		return ingestTarget{}, err
+	}
+	return ingestTarget{dir: dir, direct: false, cleanup: func() { cleanupStaging(dir) }}, nil
+}
+
 // uploadStagedFiles copies every file from stagingDir into the default storage
 // backend under destPrefix (e.g. "downloads/"). It returns the list of final
 // paths as they exist in the backend (for database insertion).

--- a/media-server/tasks/staging_test.go
+++ b/media-server/tasks/staging_test.go
@@ -1,0 +1,68 @@
+package tasks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stevecastle/shrike/storage"
+)
+
+// withStorageRegistry sets the package storageReg for the duration of a test
+// and restores the previous value afterwards.
+func withStorageRegistry(t *testing.T, r *storage.Registry) {
+	t.Helper()
+	prev := storageReg
+	storageReg = r
+	t.Cleanup(func() { storageReg = prev })
+}
+
+func TestResolveIngestDirLocalIsDirect(t *testing.T) {
+	root := t.TempDir()
+	reg := storage.NewRegistry([]storage.Backend{
+		storage.NewLocalBackend(root, "local"),
+	})
+	withStorageRegistry(t, reg)
+
+	target, err := resolveIngestDir("job-1", "downloads/")
+	if err != nil {
+		t.Fatalf("resolveIngestDir: %v", err)
+	}
+	if !target.direct {
+		t.Fatalf("expected direct mode for a local backend")
+	}
+	want := filepath.Join(root, "downloads")
+	if target.dir != want {
+		t.Fatalf("dir = %q, want %q", target.dir, want)
+	}
+	// Direct mode targets the final location, not a temp staging dir.
+	if strings.Contains(target.dir, "staging") {
+		t.Fatalf("direct dir should not be under staging: %q", target.dir)
+	}
+	// cleanup must be a no-op: the download dir must survive it.
+	target.cleanup()
+	if _, err := os.Stat(target.dir); err != nil {
+		t.Fatalf("direct download dir should survive cleanup: %v", err)
+	}
+}
+
+func TestResolveIngestDirNoBackendStages(t *testing.T) {
+	withStorageRegistry(t, nil)
+
+	target, err := resolveIngestDir("job-2", "downloads/")
+	if err != nil {
+		t.Fatalf("resolveIngestDir: %v", err)
+	}
+	if target.direct {
+		t.Fatalf("expected staging mode when no backend is configured")
+	}
+	if !strings.Contains(target.dir, "staging") {
+		t.Fatalf("staging dir expected under a staging path: %q", target.dir)
+	}
+	// cleanup must remove the staging dir.
+	target.cleanup()
+	if _, err := os.Stat(target.dir); err == nil {
+		t.Fatalf("staging dir should be removed by cleanup")
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loki",
-  "version": "2.15.0-patron-preview",
+  "version": "2.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loki",
-      "version": "2.15.0-patron-preview",
+      "version": "2.16.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loki",
-  "version": "2.14.0",
+  "version": "2.15.0-patron-preview",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loki",
-      "version": "2.14.0",
+      "version": "2.15.0-patron-preview",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loki",
-  "version": "2.14.0",
+  "version": "2.15.0-patron-preview",
   "type": "commonjs",
   "productName": "Lowkey Media Viewer",
   "description": "A Media library for quick curation.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loki",
-  "version": "2.15.0-patron-preview",
+  "version": "2.16.0",
   "type": "commonjs",
   "productName": "Lowkey Media Viewer",
   "description": "A Media library for quick curation.",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loki",
-  "version": "2.15.0-patron-preview",
+  "version": "2.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loki",
-      "version": "2.15.0-patron-preview",
+      "version": "2.16.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loki",
-  "version": "2.14.0",
+  "version": "2.15.0-patron-preview",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loki",
-      "version": "2.14.0",
+      "version": "2.15.0-patron-preview",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loki",
   "productName": "Lowkey Media Viewer",
-  "version": "2.14.0",
+  "version": "2.15.0-patron-preview",
   "description": "A Media library for quick curation.",
   "license": "MIT",
   "author": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loki",
   "productName": "Lowkey Media Viewer",
-  "version": "2.15.0-patron-preview",
+  "version": "2.16.0",
   "description": "A Media library for quick curation.",
   "license": "MIT",
   "author": {

--- a/scripts/build-server.js
+++ b/scripts/build-server.js
@@ -44,8 +44,7 @@ const ext = process.platform === 'win32' ? '.exe' : '';
 // when the user launches the .exe. `-H=windowsgui` switches the PE subsystem
 // to GUI so Windows won't allocate a console for the process. No effect on
 // macOS or Linux — those linkers ignore the flag.
-const ldflags =
-  process.platform === 'win32' ? ' -ldflags="-H=windowsgui"' : '';
+const ldflags = process.platform === 'win32' ? '' : '';
 run(`go build${ldflags} -o media-server${ext} .`, { cwd: SERVER_DIR });
 
 console.log(`\n✓ Server built: media-server/media-server${ext}`);

--- a/src/__tests__/async-timeout.test.ts
+++ b/src/__tests__/async-timeout.test.ts
@@ -1,0 +1,54 @@
+import { withTimeout, TimeoutError } from '../main/async-timeout';
+
+const delay = <T>(ms: number, value: T): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), ms));
+
+const rejectAfter = (ms: number, err: Error): Promise<never> =>
+  new Promise((_, reject) => setTimeout(() => reject(err), ms));
+
+describe('withTimeout', () => {
+  it('passes through the value when the promise settles in time', async () => {
+    await expect(withTimeout(delay(5, 'ok'), 100, 'fast')).resolves.toBe('ok');
+  });
+
+  it('rejects with a TimeoutError when the promise hangs', async () => {
+    const hang = new Promise(() => {}); // never settles
+    await expect(withTimeout(hang, 10, 'load-files')).rejects.toBeInstanceOf(
+      TimeoutError
+    );
+  });
+
+  it('TimeoutError carries the label, duration, and ETIMEDOUT code', async () => {
+    const hang = new Promise(() => {});
+    await withTimeout(hang, 10, 'load-db').catch((e: TimeoutError) => {
+      expect(e.message).toContain('load-db');
+      expect(e.message).toContain('10ms');
+      expect(e.code).toBe('ETIMEDOUT');
+    });
+  });
+
+  it('invokes the onTimeout cleanup hook so callers can kill a child', async () => {
+    const hang = new Promise(() => {});
+    const onTimeout = jest.fn();
+    await withTimeout(hang, 10, 'scan', onTimeout).catch(() => undefined);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onTimeout when the promise settles in time', async () => {
+    const onTimeout = jest.fn();
+    await withTimeout(delay(5, 'ok'), 100, 'fast', onTimeout);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('propagates the original rejection (not a timeout) when it loses the race', async () => {
+    const boom = new Error('boom');
+    await expect(withTimeout(rejectAfter(5, boom), 100, 'x')).rejects.toBe(boom);
+  });
+
+  it('disables the timeout for non-positive ms (returns the promise as-is)', async () => {
+    // A 30ms promise with ms=0 must still resolve — no timeout armed.
+    await expect(withTimeout(delay(30, 'slow'), 0, 'no-timeout')).resolves.toBe(
+      'slow'
+    );
+  });
+});

--- a/src/__tests__/context-query.test.ts
+++ b/src/__tests__/context-query.test.ts
@@ -1,0 +1,58 @@
+import {
+  getDirFromInitialFile,
+  buildLibraryPathQuery,
+} from '../renderer/components/controls/context-query';
+
+describe('getDirFromInitialFile', () => {
+  it('returns the parent directory of a file path', () => {
+    expect(getDirFromInitialFile('/photos/cats/img.jpg')).toBe('/photos/cats');
+    expect(getDirFromInitialFile('D:\\photos\\cats\\img.jpg')).toBe(
+      'D:\\photos\\cats'
+    );
+  });
+
+  it('returns a directory path unchanged', () => {
+    expect(getDirFromInitialFile('/photos/cats')).toBe('/photos/cats');
+  });
+
+  it('keeps the trailing separator on a Windows drive root', () => {
+    expect(getDirFromInitialFile('D:\\img.jpg')).toBe('D:\\');
+  });
+});
+
+describe('buildLibraryPathQuery', () => {
+  // Non-recursive: pathdir matches only the immediate directory (the server
+  // expands it to LIKE 'dir/%' AND NOT LIKE 'dir/%/%').
+  it('uses pathdir for the immediate directory when recursive is off', () => {
+    expect(buildLibraryPathQuery('/photos/cats/img.jpg', false)).toBe(
+      'pathdir:"/photos/cats"'
+    );
+    expect(buildLibraryPathQuery('D:\\photos\\cats\\img.jpg', false)).toBe(
+      'pathdir:"D:\\photos\\cats"'
+    );
+  });
+
+  // Recursive: the list view spans subdirectories, so match every path under
+  // the directory with a trailing wildcard (server: path:"dir/*" → LIKE 'dir/%').
+  it('uses a trailing-wildcard path query when recursive is on', () => {
+    expect(buildLibraryPathQuery('/photos/cats/img.jpg', true)).toBe(
+      'path:"/photos/cats/*"'
+    );
+    expect(buildLibraryPathQuery('D:\\photos\\cats\\img.jpg', true)).toBe(
+      'path:"D:\\photos\\cats\\*"'
+    );
+  });
+
+  it('handles a directory target (no file extension)', () => {
+    expect(buildLibraryPathQuery('/photos/cats', false)).toBe(
+      'pathdir:"/photos/cats"'
+    );
+    expect(buildLibraryPathQuery('/photos/cats', true)).toBe(
+      'path:"/photos/cats/*"'
+    );
+  });
+
+  it('handles a Windows drive root without doubling the separator', () => {
+    expect(buildLibraryPathQuery('D:\\img.jpg', true)).toBe('path:"D:\\*"');
+  });
+});

--- a/src/__tests__/customPromptStore.test.ts
+++ b/src/__tests__/customPromptStore.test.ts
@@ -1,6 +1,7 @@
 import {
   getLastCustomPrompt,
   setLastCustomPrompt,
+  clearLastCustomPrompt,
   getCachedDefaultPrompt,
   setCachedDefaultPrompt,
   __resetCustomPromptStoreForTests,
@@ -25,6 +26,20 @@ describe('customPromptStore', () => {
     setLastCustomPrompt('');
     setLastCustomPrompt('   ');
     expect(getLastCustomPrompt()).toBe('keep me');
+  });
+
+  it('clears the remembered prompt back to empty (reset to default)', () => {
+    setLastCustomPrompt('a custom override');
+    clearLastCustomPrompt();
+    expect(getLastCustomPrompt()).toBe('');
+  });
+
+  it('keeps the cleared prompt cleared so it does not reappear', () => {
+    setLastCustomPrompt('a custom override');
+    clearLastCustomPrompt();
+    // A no-op empty submission must not resurrect the old value.
+    setLastCustomPrompt('');
+    expect(getLastCustomPrompt()).toBe('');
   });
 
   it('returns null for cached default until set', () => {

--- a/src/__tests__/db-retry.test.ts
+++ b/src/__tests__/db-retry.test.ts
@@ -1,0 +1,129 @@
+import {
+  isDatabaseLockedError,
+  retryAsync,
+} from '../main/db-retry';
+
+describe('isDatabaseLockedError', () => {
+  it('detects SQLITE_BUSY errors by code', () => {
+    const err = Object.assign(new Error('database is locked'), {
+      code: 'SQLITE_BUSY',
+    });
+    expect(isDatabaseLockedError(err)).toBe(true);
+  });
+
+  it('detects SQLITE_LOCKED errors by code', () => {
+    const err = Object.assign(new Error('database table is locked'), {
+      code: 'SQLITE_LOCKED',
+    });
+    expect(isDatabaseLockedError(err)).toBe(true);
+  });
+
+  it('detects lock errors by message when code is absent', () => {
+    expect(isDatabaseLockedError(new Error('SQLITE_BUSY: database is locked')))
+      .toBe(true);
+    expect(isDatabaseLockedError(new Error('database is locked'))).toBe(true);
+  });
+
+  it('does not treat unrelated errors as lock errors', () => {
+    expect(isDatabaseLockedError(new Error('no such table: media'))).toBe(false);
+    expect(
+      isDatabaseLockedError(
+        Object.assign(new Error('disk full'), { code: 'SQLITE_FULL' })
+      )
+    ).toBe(false);
+    expect(isDatabaseLockedError(undefined)).toBe(false);
+    expect(isDatabaseLockedError(null)).toBe(false);
+  });
+});
+
+describe('retryAsync', () => {
+  // No-op sleep keeps tests deterministic and fast.
+  const noSleep = () => Promise.resolve();
+
+  it('returns the result when the factory succeeds on the first try', async () => {
+    let calls = 0;
+    const result = await retryAsync(
+      async () => {
+        calls += 1;
+        return 'ok';
+      },
+      { retries: 3, isRetryable: () => true, sleep: noSleep }
+    );
+    expect(result).toBe('ok');
+    expect(calls).toBe(1);
+  });
+
+  it('retries a retryable failure and eventually succeeds', async () => {
+    let calls = 0;
+    const result = await retryAsync(
+      async () => {
+        calls += 1;
+        if (calls < 3) {
+          throw Object.assign(new Error('locked'), { code: 'SQLITE_BUSY' });
+        }
+        return 'recovered';
+      },
+      {
+        retries: 5,
+        isRetryable: isDatabaseLockedError,
+        sleep: noSleep,
+      }
+    );
+    expect(result).toBe('recovered');
+    expect(calls).toBe(3);
+  });
+
+  it('does not retry a non-retryable failure', async () => {
+    let calls = 0;
+    await expect(
+      retryAsync(
+        async () => {
+          calls += 1;
+          throw new Error('no such table');
+        },
+        { retries: 5, isRetryable: isDatabaseLockedError, sleep: noSleep }
+      )
+    ).rejects.toThrow('no such table');
+    expect(calls).toBe(1);
+  });
+
+  it('gives up after exhausting retries and throws the last error', async () => {
+    let calls = 0;
+    await expect(
+      retryAsync(
+        async () => {
+          calls += 1;
+          throw Object.assign(new Error(`busy ${calls}`), {
+            code: 'SQLITE_BUSY',
+          });
+        },
+        { retries: 3, isRetryable: () => true, sleep: noSleep }
+      )
+    ).rejects.toThrow('busy 4');
+    // initial attempt + 3 retries
+    expect(calls).toBe(4);
+  });
+
+  it('waits between retries using the injected sleep with growing delays', async () => {
+    const delays: number[] = [];
+    let calls = 0;
+    await retryAsync(
+      async () => {
+        calls += 1;
+        if (calls < 3) throw Object.assign(new Error('busy'), { code: 'SQLITE_BUSY' });
+        return 'done';
+      },
+      {
+        retries: 5,
+        isRetryable: () => true,
+        baseDelayMs: 100,
+        sleep: (ms: number) => {
+          delays.push(ms);
+          return Promise.resolve();
+        },
+      }
+    );
+    // Two failures => two waits, exponential backoff from baseDelayMs.
+    expect(delays).toEqual([100, 200]);
+  });
+});

--- a/src/__tests__/detail-wheel-listener.test.tsx
+++ b/src/__tests__/detail-wheel-listener.test.tsx
@@ -1,0 +1,179 @@
+import { render, fireEvent } from '@testing-library/react';
+
+// Regression test for the detail-view scroll-wheel cursor control.
+//
+// Bug: the wheel-listener effect depended on `containerRef.current`. On the
+// initial mount the library hasn't loaded yet, so `item` is null and Detail
+// early-returns `null` — the ref'd container isn't in the DOM. Ref assignment
+// doesn't trigger a re-render, and React reads `containerRef.current` as null at
+// render time, so when the container later mounted the effect never re-ran and
+// the wheel listener was never attached. Toggling control mode forced an
+// unrelated re-render that happened to re-run the effect (the user's workaround).
+//
+// The fix keys the effect on `item?.path` (which flips null -> value when the
+// container mounts), so the listener attaches as soon as the media is available.
+
+// Mutable holders read lazily inside the mock factories (assigned before render).
+let mockState: any;
+let mockLibrary: any[] = [];
+const mockSend = jest.fn();
+
+jest.mock('@xstate/react', () => ({
+  // Ignore the equality fn; just run the selector against our fake state.
+  useSelector: (_service: any, selector: any) => selector(mockState),
+}));
+
+jest.mock('../renderer/state', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    GlobalStateContext: React.createContext({
+      libraryService: { send: (...args: any[]) => mockSend(...args) },
+    }),
+  };
+});
+
+// `filter` produces the working list the item selector cycles through.
+jest.mock('renderer/filter', () => ({
+  __esModule: true,
+  default: () => mockLibrary,
+}));
+
+jest.mock('react-scroll-ondrag', () => ({
+  __esModule: true,
+  default: () => ({ events: {} }),
+}));
+
+jest.mock('renderer/hooks/useMediaDimensions', () => ({
+  __esModule: true,
+  default: () => ({ orientation: 'landscape' }),
+}));
+
+jest.mock('renderer/hooks/useTagDrop', () => ({
+  __esModule: true,
+  default: () => ({ drop: () => undefined }),
+}));
+
+jest.mock('../file-types', () => ({
+  __esModule: true,
+  FileTypes: {
+    Video: 'video',
+    Image: 'image',
+    Audio: 'audio',
+    Document: 'document',
+    Archive: 'archive',
+    Other: 'other',
+  },
+  getFileType: () => 'image',
+}));
+
+// Stub the media viewers / child UI so the test doesn't pull their heavy deps.
+jest.mock('../renderer/components/media-viewers/image', () => ({
+  __esModule: true,
+  Image: () => null,
+}));
+jest.mock('../renderer/components/media-viewers/animated-gif', () => ({
+  __esModule: true,
+  AnimatedGif: () => null,
+}));
+jest.mock('../renderer/components/media-viewers/video', () => ({
+  __esModule: true,
+  Video: () => null,
+}));
+jest.mock('../renderer/components/media-viewers/audio', () => ({
+  __esModule: true,
+  Audio: () => null,
+}));
+jest.mock('../renderer/components/controls/video-controls', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('../renderer/components/metadata/tags', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('../renderer/components/elo/BattleMode', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import { Detail } from '../renderer/components/detail/detail';
+
+const baseSettings = {
+  controlMode: 'mouse',
+  comicMode: false,
+  battleMode: false,
+  showControls: true,
+  showTags: 'none',
+  showFileInfo: 'none',
+  filters: {},
+  sortBy: 'name',
+  scaleMode: 'cover',
+  detailImageCache: false,
+};
+
+function makeState(controlMode: string) {
+  return {
+    context: {
+      libraryLoadId: 'id',
+      textFilter: '',
+      library: [],
+      cursor: 0,
+      settings: { ...baseSettings, controlMode },
+    },
+  };
+}
+
+beforeAll(() => {
+  // jsdom has no ResizeObserver; Detail instantiates one once the container mounts.
+  (global as any).ResizeObserver = class {
+    observe() {
+      /* no-op */
+    }
+    unobserve() {
+      /* no-op */
+    }
+    disconnect() {
+      /* no-op */
+    }
+  };
+});
+
+beforeEach(() => {
+  mockSend.mockClear();
+  mockLibrary = [];
+});
+
+describe('Detail scroll-wheel cursor control', () => {
+  it('attaches the wheel->cursor listener once the container mounts after the library loads', () => {
+    mockState = makeState('mouse');
+
+    // Initial mount: library not loaded -> item null -> container not rendered.
+    mockLibrary = [];
+    const { rerender, container } = render(<Detail />);
+    expect(container.querySelector('.Detail')).toBeNull();
+
+    // Library loads -> item present -> the ref'd container mounts.
+    mockLibrary = [{ path: '/a.jpg', timeStamp: 0 }];
+    rerender(<Detail />);
+    const detail = container.querySelector('.Detail') as HTMLElement;
+    expect(detail).not.toBeNull();
+
+    // Scrolling down must move the cursor forward — proves the native wheel
+    // listener attached even though the container mounted after the first render.
+    fireEvent.wheel(detail, { deltaY: 10 });
+    expect(mockSend).toHaveBeenCalledWith('INCREMENT_CURSOR');
+  });
+
+  it('does not move the cursor on wheel in touchpad mode', () => {
+    mockState = makeState('touchpad');
+    mockLibrary = [{ path: '/a.jpg', timeStamp: 0 }];
+
+    const { container } = render(<Detail />);
+    const detail = container.querySelector('.Detail') as HTMLElement;
+    expect(detail).not.toBeNull();
+
+    fireEvent.wheel(detail, { deltaY: 10 });
+    expect(mockSend).not.toHaveBeenCalledWith('INCREMENT_CURSOR');
+  });
+});

--- a/src/__tests__/errorLog.test.ts
+++ b/src/__tests__/errorLog.test.ts
@@ -1,0 +1,79 @@
+import os from 'os';
+import path from 'path';
+
+// Mock electron's app so errorLog resolves its path to a temp dir instead of a
+// real userData location. Must be declared before importing errorLog.
+const TMP_DIR = path.join(os.tmpdir(), 'loki-errorlog-test');
+jest.mock('electron', () => ({
+  app: { getPath: () => TMP_DIR },
+}));
+
+import fs from 'fs';
+import {
+  serializeError,
+  logEvent,
+  getAppLogPath,
+  flushAppLog,
+} from '../main/errorLog';
+
+describe('serializeError', () => {
+  it('extracts message, stack, name, and code from an Error', () => {
+    const err = Object.assign(new Error('database is locked'), {
+      code: 'SQLITE_BUSY',
+    });
+    const out = serializeError(err) as Record<string, unknown>;
+    expect(out.name).toBe('Error');
+    expect(out.message).toBe('database is locked');
+    expect(out.code).toBe('SQLITE_BUSY');
+    expect(typeof out.stack).toBe('string');
+  });
+
+  it('handles null/undefined and primitive values', () => {
+    expect(serializeError(null)).toBeNull();
+    expect(serializeError(undefined)).toBeNull();
+    expect(serializeError('plain string')).toEqual({ value: 'plain string' });
+    expect(serializeError(42)).toEqual({ value: '42' });
+  });
+
+  it('passes through plain objects', () => {
+    expect(serializeError({ foo: 'bar' })).toEqual({ foo: 'bar' });
+  });
+});
+
+describe('logEvent', () => {
+  beforeAll(() => {
+    fs.mkdirSync(TMP_DIR, { recursive: true });
+    // Start from a clean file.
+    try {
+      fs.rmSync(getAppLogPath());
+    } catch {
+      // not there yet — fine
+    }
+  });
+
+  afterAll(async () => {
+    await flushAppLog();
+  });
+
+  it('appends a JSON line with the expected shape', async () => {
+    logEvent({
+      scope: 'ipc:load-files',
+      message: 'load-files failed',
+      data: { filePath: 'C:/x' },
+      error: Object.assign(new Error('stalled'), { code: 'ETIMEDOUT' }),
+    });
+    await flushAppLog();
+
+    const contents = fs.readFileSync(getAppLogPath(), 'utf8').trim();
+    const lines = contents.split('\n').filter(Boolean);
+    const last = JSON.parse(lines[lines.length - 1]);
+
+    expect(last.scope).toBe('ipc:load-files');
+    expect(last.message).toBe('load-files failed');
+    expect(last.level).toBe('error');
+    expect(last.source).toBe('electron');
+    expect(last.data).toEqual({ filePath: 'C:/x' });
+    expect(last.error.code).toBe('ETIMEDOUT');
+    expect(typeof last.ts).toBe('string');
+  });
+});

--- a/src/__tests__/loaded-from-fs-persistence.test.ts
+++ b/src/__tests__/loaded-from-fs-persistence.test.ts
@@ -3,7 +3,7 @@
  *
  * Bug: when the state machine enters `loadedFromFS`, the in-memory invariant
  * forces `dbQuery.tags=[]` and `textFilter=''` — but unlike the analogous
- * `loadedFromDB` and `loadedFromSearch` entries, it never mirrors that
+ * `loadedFromDB` entry, it never mirrors that
  * cleared state to the session store. As a result, on-disk session.query
  * could retain stale tags while session.library held an FS-loaded folder.
  * On next boot, `loadingFromPersisted` would route the FS library into

--- a/src/__tests__/query-events.test.ts
+++ b/src/__tests__/query-events.test.ts
@@ -1,0 +1,16 @@
+import { applyTagClick, addPredicate } from '../renderer/query/reducer';
+
+// Documents the contract the machine relies on.
+it('tag click contract produces a tag predicate', () => {
+  expect(applyTagClick({ predicates: [] }, 'x', 'AND').predicates[0]).toEqual({
+    type: 'tag',
+    value: 'x',
+    exclude: false,
+  });
+});
+it('add predicate contract', () => {
+  expect(
+    addPredicate({ predicates: [] }, { type: 'path', value: 'p', exclude: false })
+      .predicates
+  ).toHaveLength(1);
+});

--- a/src/__tests__/query-events.test.ts
+++ b/src/__tests__/query-events.test.ts
@@ -6,6 +6,7 @@ it('tag click contract produces a tag predicate', () => {
     type: 'tag',
     value: 'x',
     exclude: false,
+    join: 'AND',
   });
 });
 it('add predicate contract', () => {

--- a/src/__tests__/query-input-clear.test.tsx
+++ b/src/__tests__/query-input-clear.test.tsx
@@ -1,0 +1,62 @@
+import { render, fireEvent } from '@testing-library/react';
+import QueryInput from '../renderer/components/query-input/QueryInput';
+import type { Query } from '../renderer/query/types';
+
+// Mock the search-history hook so the test doesn't transitively pull in
+// platform.ts (which carries unrelated, pre-existing type errors that would
+// fail ts-jest). The clear button doesn't depend on history behaviour.
+jest.mock('../renderer/hooks/useSearchHistory', () => ({
+  useSearchHistory: () => ({
+    history: [],
+    addSearch: () => {},
+    removeSearch: () => {},
+    clearAll: () => {},
+  }),
+}));
+
+// The clear button must distinguish two cases:
+//  - filters present  -> full clear (chips + text), which resets the library.
+//  - only text typed  -> clear the text only; a no-op on the library.
+function renderInput(query: Query, textValue: string) {
+  const onClearAll = jest.fn();
+  const onClearText = jest.fn();
+  const utils = render(
+    <QueryInput
+      query={query}
+      textValue={textValue}
+      onTextChange={() => {}}
+      onSubmitText={() => {}}
+      onRemovePredicate={() => {}}
+      onToggleExclude={() => {}}
+      onSetPredicateJoin={() => {}}
+      onClearAll={onClearAll}
+      onClearText={onClearText}
+    />
+  );
+  const clearButton = utils.container.querySelector(
+    '.query-input-clear'
+  ) as HTMLButtonElement;
+  return { onClearAll, onClearText, clearButton };
+}
+
+describe('QueryInput clear button', () => {
+  it('clears everything (library reset) when predicates are present', () => {
+    const query: Query = {
+      predicates: [{ type: 'tag', value: 'cats', exclude: false }],
+    };
+    const { onClearAll, onClearText, clearButton } = renderInput(query, 'dog');
+    fireEvent.click(clearButton);
+    expect(onClearAll).toHaveBeenCalledTimes(1);
+    expect(onClearText).not.toHaveBeenCalled();
+  });
+
+  it('clears only the text (no library reset) when no predicates are present', () => {
+    const { onClearAll, onClearText, clearButton } = renderInput(
+      { predicates: [] },
+      'dog'
+    );
+    fireEvent.click(clearButton);
+    expect(onClearText).toHaveBeenCalledTimes(1);
+    expect(onClearAll).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/query-input-dropdown.test.tsx
+++ b/src/__tests__/query-input-dropdown.test.tsx
@@ -1,0 +1,56 @@
+import { render, fireEvent } from '@testing-library/react';
+import QueryInput from '../renderer/components/query-input/QueryInput';
+import type { Query } from '../renderer/query/types';
+
+// Provide a non-empty history so the dropdown *would* render if it were open —
+// that's the whole point of these tests: the dropdown's open/closed state, not
+// whether it has items to show.
+jest.mock('../renderer/hooks/useSearchHistory', () => ({
+  useSearchHistory: () => ({
+    history: ['cats', 'dogs'],
+    addSearch: () => {},
+    removeSearch: () => {},
+    clearAll: () => {},
+  }),
+}));
+
+const EMPTY_QUERY: Query = { predicates: [] };
+
+function renderInput(extraProps: Partial<React.ComponentProps<typeof QueryInput>> = {}) {
+  const utils = render(
+    <QueryInput
+      query={EMPTY_QUERY}
+      textValue=""
+      onTextChange={() => {}}
+      onSubmitText={() => {}}
+      onRemovePredicate={() => {}}
+      onToggleExclude={() => {}}
+      onSetPredicateJoin={() => {}}
+      onClearAll={() => {}}
+      onClearText={() => {}}
+      {...extraProps}
+    />
+  );
+  const dropdown = () => utils.container.querySelector('.query-input-dropdown');
+  const input = utils.container.querySelector('input') as HTMLInputElement;
+  return { ...utils, dropdown, input };
+}
+
+describe('QueryInput history dropdown', () => {
+  it('does NOT open on mount even with autoFocus (programmatic focus is not user intent)', () => {
+    const { dropdown } = renderInput({ autoFocus: true });
+    expect(dropdown()).toBeNull();
+  });
+
+  it('opens when the user starts typing', () => {
+    const { dropdown, input } = renderInput({ autoFocus: true });
+    fireEvent.change(input, { target: { value: 'c' } });
+    expect(dropdown()).not.toBeNull();
+  });
+
+  it('opens when the user intentionally mouses down on the input', () => {
+    const { dropdown, input } = renderInput();
+    fireEvent.mouseDown(input);
+    expect(dropdown()).not.toBeNull();
+  });
+});

--- a/src/__tests__/query-input-dropdown.test.tsx
+++ b/src/__tests__/query-input-dropdown.test.tsx
@@ -54,3 +54,28 @@ describe('QueryInput history dropdown', () => {
     expect(dropdown()).not.toBeNull();
   });
 });
+
+describe('QueryInput result navigation (resultNavCount > 0)', () => {
+  it('routes arrow keys and Enter to the parent result nav', () => {
+    const onResultNavMove = jest.fn();
+    const onResultNavSubmit = jest.fn();
+    const { input } = renderInput({
+      resultNavCount: 3,
+      onResultNavMove,
+      onResultNavSubmit,
+    });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onResultNavMove.mock.calls).toEqual([[1], [-1]]);
+    expect(onResultNavSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses the history dropdown so it does not overlap the results', () => {
+    const { dropdown, input } = renderInput({ resultNavCount: 3 });
+    // Typing would normally open the dropdown; with result nav active it stays
+    // closed because the parent's results surface is the navigation target.
+    fireEvent.change(input, { target: { value: 'c' } });
+    expect(dropdown()).toBeNull();
+  });
+});

--- a/src/__tests__/query-input-filter-mode.test.tsx
+++ b/src/__tests__/query-input-filter-mode.test.tsx
@@ -1,0 +1,69 @@
+import { render, fireEvent } from '@testing-library/react';
+import QueryInput from '../renderer/components/query-input/QueryInput';
+import type { Query } from '../renderer/query/types';
+
+// Mock the search-history hook so the test doesn't transitively pull in
+// platform.ts (which carries unrelated, pre-existing type errors that would
+// fail ts-jest). The filter-mode toggle doesn't depend on history behaviour.
+jest.mock('../renderer/hooks/useSearchHistory', () => ({
+  useSearchHistory: () => ({
+    history: [],
+    addSearch: () => {},
+    removeSearch: () => {},
+    clearAll: () => {},
+  }),
+}));
+
+const baseProps = {
+  query: { predicates: [] } as Query,
+  textValue: '',
+  onTextChange: () => {},
+  onSubmitText: () => {},
+  onRemovePredicate: () => {},
+  onToggleExclude: () => {},
+  onSetPredicateJoin: () => {},
+  onClearAll: () => {},
+  onClearText: () => {},
+};
+
+describe('QueryInput filtering-mode toggle', () => {
+  it('does not render the toggle when no filteringMode is supplied', () => {
+    const utils = render(<QueryInput {...baseProps} />);
+    expect(
+      utils.container.querySelector('.query-input-filter-mode')
+    ).toBeNull();
+  });
+
+  it('renders the toggle and cycles the mode when supplied', () => {
+    const onCycleFilterMode = jest.fn();
+    const utils = render(
+      <QueryInput
+        {...baseProps}
+        filteringMode="AND"
+        onCycleFilterMode={onCycleFilterMode}
+      />
+    );
+    const button = utils.container.querySelector(
+      '.query-input-filter-mode'
+    ) as HTMLButtonElement;
+    expect(button).not.toBeNull();
+    fireEvent.click(button);
+    expect(onCycleFilterMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the query-syntax help button alongside the new toggle (additive)', () => {
+    const utils = render(
+      <QueryInput
+        {...baseProps}
+        filteringMode="OR"
+        onCycleFilterMode={() => {}}
+      />
+    );
+    expect(
+      utils.container.querySelector('.query-input-help')
+    ).not.toBeNull();
+    expect(
+      utils.container.querySelector('.query-input-filter-mode')
+    ).not.toBeNull();
+  });
+});

--- a/src/__tests__/query-parse.test.ts
+++ b/src/__tests__/query-parse.test.ts
@@ -1,0 +1,44 @@
+// src/__tests__/query-parse.test.ts
+import { parseQuery, serializeQuery } from '../renderer/query/parse';
+import type { Predicate } from '../renderer/query/types';
+
+describe('parseQuery', () => {
+  it('parses tag, category, path, description, hash prefixes', () => {
+    expect(parseQuery('#portrait in:Studio path:2023/ description:sunset hash:abc'))
+      .toEqual<Predicate[]>([
+        { type: 'tag', value: 'portrait', exclude: false },
+        { type: 'category', value: 'Studio', exclude: false },
+        { type: 'path', value: '2023/', exclude: false },
+        { type: 'description', value: 'sunset', exclude: false },
+        { type: 'hash', value: 'abc', exclude: false },
+      ]);
+  });
+
+  it('honors leading - as exclude on any prefix', () => {
+    expect(parseQuery('-#blurry -path:tmp')).toEqual<Predicate[]>([
+      { type: 'tag', value: 'blurry', exclude: true },
+      { type: 'path', value: 'tmp', exclude: true },
+    ]);
+  });
+
+  it('keeps quoted phrases intact', () => {
+    expect(parseQuery('description:"studio session"')).toEqual<Predicate[]>([
+      { type: 'description', value: 'studio session', exclude: false },
+    ]);
+  });
+
+  it('treats a bare token as a description predicate', () => {
+    expect(parseQuery('sunset')).toEqual<Predicate[]>([
+      { type: 'description', value: 'sunset', exclude: false },
+    ]);
+  });
+
+  it('round-trips through serializeQuery', () => {
+    const preds = parseQuery('#portrait -#blurry in:Studio path:"a b" hash:xyz');
+    expect(parseQuery(serializeQuery({ predicates: preds }))).toEqual(preds);
+  });
+
+  it('ignores empty tokens', () => {
+    expect(parseQuery('   ')).toEqual([]);
+  });
+});

--- a/src/__tests__/query-reducer.test.ts
+++ b/src/__tests__/query-reducer.test.ts
@@ -1,0 +1,44 @@
+// src/__tests__/query-reducer.test.ts
+import { addPredicate, removePredicate, toggleExclude, applyTagClick } from '../renderer/query/reducer';
+import type { Query } from '../renderer/query/types';
+
+const q = (preds: Query['predicates']): Query => ({ predicates: preds });
+
+describe('query reducer', () => {
+  it('adds a predicate', () => {
+    expect(addPredicate(q([]), { type: 'tag', value: 'a', exclude: false }))
+      .toEqual(q([{ type: 'tag', value: 'a', exclude: false }]));
+  });
+
+  it('does not duplicate an identical predicate', () => {
+    const start = q([{ type: 'tag', value: 'a', exclude: false }]);
+    expect(addPredicate(start, { type: 'tag', value: 'a', exclude: false })).toEqual(start);
+  });
+
+  it('removes a predicate by key', () => {
+    const start = q([{ type: 'tag', value: 'a', exclude: false }, { type: 'path', value: 'p', exclude: false }]);
+    expect(removePredicate(start, '-tag:a'.replace('-', ''))).toBeDefined();
+    expect(removePredicate(start, 'tag:a').predicates).toEqual([{ type: 'path', value: 'p', exclude: false }]);
+  });
+
+  it('toggles exclude on a predicate', () => {
+    const start = q([{ type: 'tag', value: 'a', exclude: false }]);
+    expect(toggleExclude(start, 'tag:a').predicates[0].exclude).toBe(true);
+  });
+
+  it('applyTagClick toggles a tag in non-exclusive modes', () => {
+    expect(applyTagClick(q([]), 'a', 'AND').predicates).toEqual([{ type: 'tag', value: 'a', exclude: false }]);
+    const has = q([{ type: 'tag', value: 'a', exclude: false }]);
+    expect(applyTagClick(has, 'a', 'AND').predicates).toEqual([]);
+  });
+
+  it('applyTagClick replaces whole query in EXCLUSIVE mode', () => {
+    const start = q([{ type: 'tag', value: 'a', exclude: false }, { type: 'path', value: 'p', exclude: false }]);
+    expect(applyTagClick(start, 'b', 'EXCLUSIVE').predicates).toEqual([{ type: 'tag', value: 'b', exclude: false }]);
+  });
+
+  it('applyTagClick in EXCLUSIVE toggles off when clicking the only active tag', () => {
+    const start = q([{ type: 'tag', value: 'b', exclude: false }]);
+    expect(applyTagClick(start, 'b', 'EXCLUSIVE').predicates).toEqual([]);
+  });
+});

--- a/src/__tests__/query-reducer.test.ts
+++ b/src/__tests__/query-reducer.test.ts
@@ -1,5 +1,5 @@
 // src/__tests__/query-reducer.test.ts
-import { addPredicate, removePredicate, toggleExclude, applyTagClick, setPredicateJoin } from '../renderer/query/reducer';
+import { addPredicate, removePredicate, toggleExclude, applyTagClick, setPredicateJoin, tagsFromQuery } from '../renderer/query/reducer';
 import type { Query } from '../renderer/query/types';
 
 const q = (preds: Query['predicates']): Query => ({ predicates: preds });
@@ -56,5 +56,15 @@ describe('query reducer', () => {
   it('setPredicateJoin changes a predicate join by key', () => {
     const start = q([{ type: 'tag', value: 'a', exclude: false, join: 'AND' }]);
     expect(setPredicateJoin(start, 'tag:a', 'OR').predicates[0].join).toBe('OR');
+  });
+
+  it('tagsFromQuery returns only included tag values', () => {
+    const q2 = q([
+      { type: 'tag', value: 'a', exclude: false },
+      { type: 'tag', value: 'b', exclude: true },
+      { type: 'path', value: 'p', exclude: false },
+      { type: 'tag', value: 'c', exclude: false },
+    ]);
+    expect(tagsFromQuery(q2)).toEqual(['a', 'c']);
   });
 });

--- a/src/__tests__/query-reducer.test.ts
+++ b/src/__tests__/query-reducer.test.ts
@@ -41,4 +41,9 @@ describe('query reducer', () => {
     const start = q([{ type: 'tag', value: 'b', exclude: false }]);
     expect(applyTagClick(start, 'b', 'EXCLUSIVE').predicates).toEqual([]);
   });
+
+  it('applyTagClick in EXCLUSIVE clears when clicking an active tag among several', () => {
+    const start = q([{ type: 'tag', value: 'a', exclude: false }, { type: 'tag', value: 'b', exclude: false }]);
+    expect(applyTagClick(start, 'a', 'EXCLUSIVE').predicates).toEqual([]);
+  });
 });

--- a/src/__tests__/query-reducer.test.ts
+++ b/src/__tests__/query-reducer.test.ts
@@ -41,9 +41,31 @@ describe('query reducer', () => {
     expect(removePredicate(start, 'tag:a').predicates).toEqual([{ type: 'path', value: 'p', exclude: false }]);
   });
 
-  it('toggles exclude on a predicate', () => {
+  it('toggles exclude when another include predicate remains', () => {
+    const start = q([
+      { type: 'tag', value: 'a', exclude: false },
+      { type: 'tag', value: 'b', exclude: false },
+    ]);
+    const next = toggleExclude(start, 'tag:a');
+    expect(next.predicates[0].exclude).toBe(true);
+  });
+
+  it('does NOT toggle the only include predicate to exclude (all-exclude scans the whole DB)', () => {
     const start = q([{ type: 'tag', value: 'a', exclude: false }]);
-    expect(toggleExclude(start, 'tag:a').predicates[0].exclude).toBe(true);
+    expect(toggleExclude(start, 'tag:a')).toBe(start); // unchanged no-op
+  });
+
+  it('does NOT toggle the last include to exclude when others are already excluded', () => {
+    const start = q([
+      { type: 'tag', value: 'a', exclude: false },
+      { type: 'tag', value: 'b', exclude: true },
+    ]);
+    expect(toggleExclude(start, 'tag:a')).toBe(start); // would leave zero includes
+  });
+
+  it('always allows toggling an exclude back to include', () => {
+    const start = q([{ type: 'tag', value: 'a', exclude: true }]);
+    expect(toggleExclude(start, '-tag:a').predicates[0].exclude).toBe(false);
   });
 
   it('applyTagClick toggles a tag in non-exclusive modes', () => {

--- a/src/__tests__/query-reducer.test.ts
+++ b/src/__tests__/query-reducer.test.ts
@@ -1,5 +1,5 @@
 // src/__tests__/query-reducer.test.ts
-import { addPredicate, removePredicate, toggleExclude, applyTagClick, setPredicateJoin, tagsFromQuery } from '../renderer/query/reducer';
+import { addPredicate, removePredicate, toggleExclude, applyTagClick, setPredicateJoin, tagsFromQuery, addPredicateWithMode } from '../renderer/query/reducer';
 import type { Query } from '../renderer/query/types';
 
 const q = (preds: Query['predicates']): Query => ({ predicates: preds });
@@ -13,6 +13,26 @@ describe('query reducer', () => {
   it('does not duplicate an identical predicate', () => {
     const start = q([{ type: 'tag', value: 'a', exclude: false }]);
     expect(addPredicate(start, { type: 'tag', value: 'a', exclude: false })).toEqual(start);
+  });
+
+  it('addPredicateWithMode appends in AND/OR', () => {
+    const start = q([{ type: 'tag', value: 'a', exclude: false }]);
+    expect(
+      addPredicateWithMode(start, { type: 'path', value: 'p', exclude: false }, 'AND').predicates
+    ).toEqual([
+      { type: 'tag', value: 'a', exclude: false },
+      { type: 'path', value: 'p', exclude: false },
+    ]);
+  });
+
+  it('addPredicateWithMode replaces the whole query in EXCLUSIVE for any predicate type', () => {
+    const start = q([
+      { type: 'tag', value: 'a', exclude: false },
+      { type: 'category', value: 'Studio', exclude: false },
+    ]);
+    expect(
+      addPredicateWithMode(start, { type: 'path', value: 'p', exclude: false }, 'EXCLUSIVE').predicates
+    ).toEqual([{ type: 'path', value: 'p', exclude: false }]);
   });
 
   it('removes a predicate by key', () => {

--- a/src/__tests__/query-reducer.test.ts
+++ b/src/__tests__/query-reducer.test.ts
@@ -1,5 +1,5 @@
 // src/__tests__/query-reducer.test.ts
-import { addPredicate, removePredicate, toggleExclude, applyTagClick } from '../renderer/query/reducer';
+import { addPredicate, removePredicate, toggleExclude, applyTagClick, setPredicateJoin } from '../renderer/query/reducer';
 import type { Query } from '../renderer/query/types';
 
 const q = (preds: Query['predicates']): Query => ({ predicates: preds });
@@ -27,14 +27,14 @@ describe('query reducer', () => {
   });
 
   it('applyTagClick toggles a tag in non-exclusive modes', () => {
-    expect(applyTagClick(q([]), 'a', 'AND').predicates).toEqual([{ type: 'tag', value: 'a', exclude: false }]);
+    expect(applyTagClick(q([]), 'a', 'AND').predicates).toEqual([{ type: 'tag', value: 'a', exclude: false, join: 'AND' }]);
     const has = q([{ type: 'tag', value: 'a', exclude: false }]);
     expect(applyTagClick(has, 'a', 'AND').predicates).toEqual([]);
   });
 
   it('applyTagClick replaces whole query in EXCLUSIVE mode', () => {
     const start = q([{ type: 'tag', value: 'a', exclude: false }, { type: 'path', value: 'p', exclude: false }]);
-    expect(applyTagClick(start, 'b', 'EXCLUSIVE').predicates).toEqual([{ type: 'tag', value: 'b', exclude: false }]);
+    expect(applyTagClick(start, 'b', 'EXCLUSIVE').predicates).toEqual([{ type: 'tag', value: 'b', exclude: false, join: 'AND' }]);
   });
 
   it('applyTagClick in EXCLUSIVE toggles off when clicking the only active tag', () => {
@@ -45,5 +45,16 @@ describe('query reducer', () => {
   it('applyTagClick in EXCLUSIVE clears when clicking an active tag among several', () => {
     const start = q([{ type: 'tag', value: 'a', exclude: false }, { type: 'tag', value: 'b', exclude: false }]);
     expect(applyTagClick(start, 'a', 'EXCLUSIVE').predicates).toEqual([]);
+  });
+
+  it('applyTagClick sets join to OR in OR mode', () => {
+    expect(applyTagClick(q([]), 'a', 'OR').predicates).toEqual([
+      { type: 'tag', value: 'a', exclude: false, join: 'OR' },
+    ]);
+  });
+
+  it('setPredicateJoin changes a predicate join by key', () => {
+    const start = q([{ type: 'tag', value: 'a', exclude: false, join: 'AND' }]);
+    expect(setPredicateJoin(start, 'tag:a', 'OR').predicates[0].join).toBe('OR');
   });
 });

--- a/src/__tests__/query-sql.test.ts
+++ b/src/__tests__/query-sql.test.ts
@@ -76,4 +76,29 @@ describe('buildMediaQuery', () => {
     ).sql);
     expect(a).toContain(') AND (');
   });
+
+  it('faceted: per-predicate join buckets AND-required with OR-group', () => {
+    const { sql, params } = buildMediaQuery(
+      [
+        { type: 'tag', value: 'a', exclude: false, join: 'AND' },
+        { type: 'tag', value: 'b', exclude: false, join: 'OR' },
+        { type: 'tag', value: 'c', exclude: false, join: 'OR' },
+      ],
+      'AND'
+    );
+    expect(norm(sql)).toContain(') AND ((');
+    expect(norm(sql)).toContain(') OR (');
+    expect(params).toEqual(['a', 'b', 'c']);
+  });
+
+  it('per-predicate join overrides the mode argument', () => {
+    const { sql } = buildMediaQuery(
+      [
+        { type: 'tag', value: 'a', exclude: false, join: 'OR' },
+        { type: 'tag', value: 'b', exclude: false, join: 'OR' },
+      ],
+      'AND'
+    );
+    expect(norm(sql)).toContain(') OR (');
+  });
 });

--- a/src/__tests__/query-sql.test.ts
+++ b/src/__tests__/query-sql.test.ts
@@ -1,0 +1,79 @@
+// src/__tests__/query-sql.test.ts
+import { buildMediaQuery } from '../main/query-sql';
+import type { Predicate } from '../renderer/query/types';
+
+const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
+
+describe('buildMediaQuery', () => {
+  it('returns base query with no predicates', () => {
+    const { sql, params } = buildMediaQuery([], 'AND');
+    expect(norm(sql)).toBe(
+      norm('SELECT media.path, media.description, media.elo, media.height, media.width FROM media')
+    );
+    expect(params).toEqual([]);
+  });
+
+  it('builds an include tag predicate with EXISTS', () => {
+    const preds: Predicate[] = [{ type: 'tag', value: 'portrait', exclude: false }];
+    const { sql, params } = buildMediaQuery(preds, 'AND');
+    expect(sql).toContain('EXISTS');
+    expect(sql).toContain('mtc.tag_label = ?');
+    expect(params).toEqual(['portrait']);
+  });
+
+  it('builds exclude tag with NOT EXISTS', () => {
+    const { sql } = buildMediaQuery([{ type: 'tag', value: 'x', exclude: true }], 'AND');
+    expect(norm(sql)).toContain('NOT EXISTS');
+  });
+
+  it('uses category_label for category predicates', () => {
+    const { sql, params } = buildMediaQuery([{ type: 'category', value: 'Studio', exclude: false }], 'AND');
+    expect(sql).toContain('mtc.category_label = ?');
+    expect(params).toEqual(['Studio']);
+  });
+
+  it('wraps path/description/hash values in % for LIKE', () => {
+    const { sql, params } = buildMediaQuery(
+      [
+        { type: 'path', value: 'a', exclude: false },
+        { type: 'description', value: 'b', exclude: true },
+        { type: 'hash', value: 'c', exclude: false },
+      ],
+      'AND'
+    );
+    expect(sql).toContain('media.path LIKE ?');
+    expect(sql).toContain('media.description NOT LIKE ?');
+    expect(sql).toContain('media.hash LIKE ?');
+    expect(params).toEqual(['%a%', '%b%', '%c%']);
+  });
+
+  it('joins clauses with OR in OR mode', () => {
+    const { sql } = buildMediaQuery(
+      [
+        { type: 'tag', value: 'a', exclude: false },
+        { type: 'tag', value: 'b', exclude: false },
+      ],
+      'OR'
+    );
+    expect(norm(sql)).toContain(') OR (');
+  });
+
+  it('joins clauses with AND in AND mode', () => {
+    const { sql } = buildMediaQuery(
+      [
+        { type: 'tag', value: 'a', exclude: false },
+        { type: 'tag', value: 'b', exclude: false },
+      ],
+      'AND'
+    );
+    expect(norm(sql)).toContain(') AND (');
+  });
+
+  it('treats EXCLUSIVE like AND for SQL joining', () => {
+    const a = norm(buildMediaQuery(
+      [{ type: 'tag', value: 'a', exclude: false }, { type: 'tag', value: 'b', exclude: false }],
+      'EXCLUSIVE'
+    ).sql);
+    expect(a).toContain(') AND (');
+  });
+});

--- a/src/__tests__/query-sql.test.ts
+++ b/src/__tests__/query-sql.test.ts
@@ -33,10 +33,38 @@ describe('buildMediaQuery', () => {
     expect(norm(sql)).toContain('NOT EXISTS');
   });
 
-  it('uses category_label for category predicates', () => {
+  it('drives a single category from the indexed category table (DISTINCT, no media scan)', () => {
     const { sql, params } = buildMediaQuery([{ type: 'category', value: 'Studio', exclude: false }], 'AND');
-    expect(sql).toContain('mtc.category_label = ?');
+    expect(sql).toContain('SELECT DISTINCT media_path FROM media_tag_by_category WHERE category_label = ?');
+    expect(sql).toContain('JOIN media ON media.path = cat.media_path');
+    expect(sql).toContain('NULL AS weight'); // a category has no single per-tag weight
     expect(params).toEqual(['Studio']);
+  });
+
+  it('drives an OR-set of categories from category_label IN (DISTINCT)', () => {
+    const { sql, params } = buildMediaQuery(
+      [
+        { type: 'category', value: 'A', exclude: false },
+        { type: 'category', value: 'B', exclude: false },
+      ],
+      'OR'
+    );
+    expect(sql).toContain('WHERE category_label IN (?, ?)');
+    expect(sql).toContain('JOIN media ON media.path = cat.media_path');
+    expect(params).toEqual(['A', 'B']);
+  });
+
+  it('a tag drives over a category (category becomes an EXISTS conjunct)', () => {
+    const { sql, params } = buildMediaQuery(
+      [
+        { type: 'tag', value: 't', exclude: false },
+        { type: 'category', value: 'C', exclude: false },
+      ],
+      'AND'
+    );
+    expect(sql).toContain('FROM media_tag_by_category mtcw'); // tag drive
+    expect(sql).toContain('mtc.category_label = ?'); // category as EXISTS
+    expect(params).toEqual(['t', 'C']);
   });
 
   it('wraps path/description/hash values in % for LIKE', () => {

--- a/src/__tests__/query-sql.test.ts
+++ b/src/__tests__/query-sql.test.ts
@@ -8,7 +8,7 @@ describe('buildMediaQuery', () => {
   it('returns base query with no predicates', () => {
     const { sql, params } = buildMediaQuery([], 'AND');
     expect(norm(sql)).toBe(
-      norm('SELECT media.path, media.description, media.elo, media.height, media.width, NULL AS weight, NULL AS tag_label, NULL AS time_stamp, NULL AS created_at FROM media')
+      norm('SELECT media.path, media.elo, media.height, media.width, NULL AS weight, NULL AS tag_label, NULL AS time_stamp, NULL AS created_at FROM media')
     );
     expect(params).toEqual([]);
   });
@@ -21,7 +21,10 @@ describe('buildMediaQuery', () => {
     expect(sql).toContain('FROM media_tag_by_category mtcw');
     expect(sql).toContain('WHERE mtcw.tag_label = ?');
     expect(sql).not.toContain('EXISTS');
-    expect(sql).toContain('ORDER BY mtcw.weight');
+    // Ordering is done in the renderer; no SQL sort, and description is not
+    // returned (only filtered).
+    expect(sql).not.toContain('ORDER BY');
+    expect(sql).not.toContain('description');
     expect(params).toEqual(['portrait']);
   });
 
@@ -46,20 +49,26 @@ describe('buildMediaQuery', () => {
       'AND'
     );
     expect(sql).toContain('media.path LIKE ?');
-    expect(sql).toContain('media.description NOT LIKE ?');
+    expect(sql).toContain('media.description NOT LIKE ?'); // filtered...
+    expect(sql).not.toContain('AS description'); // ...but never returned
     expect(sql).toContain('media.hash LIKE ?');
     expect(params).toEqual(['%a%', '%b%', '%c%']);
   });
 
-  it('joins clauses with OR in OR mode', () => {
-    const { sql } = buildMediaQuery(
+  it('drives an OR-set of include-tags from a tag_label IN lookup', () => {
+    const { sql, params } = buildMediaQuery(
       [
         { type: 'tag', value: 'a', exclude: false },
         { type: 'tag', value: 'b', exclude: false },
       ],
       'OR'
     );
-    expect(norm(sql)).toContain(') OR (');
+    // No media scan: indexed IN over the tag table.
+    expect(sql).toContain('FROM media_tag_by_category mtcw');
+    expect(sql).toContain('WHERE mtcw.tag_label IN (?, ?)');
+    expect(sql).not.toContain('EXISTS');
+    expect(sql).not.toContain('ORDER BY');
+    expect(params).toEqual(['a', 'b']);
   });
 
   it('drives from the first AND-tag and adds other tags as conjunct EXISTS', () => {
@@ -102,16 +111,16 @@ describe('buildMediaQuery', () => {
     expect(params).toEqual(['a', 'b', 'c']); // drive a, then EXISTS b, c
   });
 
-  it('OR-only tags fall back to a media scan with an OR group', () => {
-    const { sql, params } = buildMediaQuery(
+  it('an OR bucket mixing tags with a non-tag falls back to a media scan', () => {
+    const { sql } = buildMediaQuery(
       [
         { type: 'tag', value: 'a', exclude: false, join: 'OR' },
-        { type: 'tag', value: 'b', exclude: false, join: 'OR' },
+        { type: 'path', value: 'p', exclude: false, join: 'OR' },
       ],
       'AND'
     );
-    // Cannot drive from an optional OR-tag — fall back to FROM media + EXISTS.
-    expect(sql).toContain('FROM media LEFT JOIN media_tag_by_category mtcw');
+    // Mixed OR bucket (tag OR path) can't be an indexed tag IN — media scan.
+    expect(sql).toContain('FROM media');
     expect(norm(sql)).toContain(') OR (');
   });
 
@@ -122,7 +131,6 @@ describe('buildMediaQuery', () => {
     );
     expect(sql).toContain('mtcw.time_stamp AS time_stamp');
     expect(sql).toContain('mtcw.weight AS weight');
-    expect(sql).toContain('ORDER BY mtcw.weight');
     expect(params[0]).toBe('cat');
   });
 

--- a/src/__tests__/query-sql.test.ts
+++ b/src/__tests__/query-sql.test.ts
@@ -124,19 +124,46 @@ describe('buildMediaQuery', () => {
     expect(params).toEqual(['a', 'b']);
   });
 
-  it('faceted: drives from the AND-tag and ORs the OR-bucket', () => {
+  it('linear: a second tag with an OR join unions (the reported bug)', () => {
+    // [a, b(OR)] reads "a OR b" — must be a UNION, not an intersection.
     const { sql, params } = buildMediaQuery(
       [
-        { type: 'tag', value: 'a', exclude: false, join: 'AND' },
+        { type: 'tag', value: 'a', exclude: false }, // base (first chip)
+        { type: 'tag', value: 'b', exclude: false, join: 'OR' },
+      ],
+      'AND'
+    );
+    expect(sql).toContain('WHERE mtcw.tag_label IN (?, ?)');
+    expect(sql).not.toContain('EXISTS'); // not an intersection
+    expect(params).toEqual(['a', 'b']);
+  });
+
+  it('linear: all-OR connectors union every tag (first chip join ignored)', () => {
+    const { sql, params } = buildMediaQuery(
+      [
+        { type: 'tag', value: 'a', exclude: false, join: 'AND' }, // base — ignored
         { type: 'tag', value: 'b', exclude: false, join: 'OR' },
         { type: 'tag', value: 'c', exclude: false, join: 'OR' },
       ],
       'AND'
     );
-    expect(sql).toContain('FROM media_tag_by_category mtcw');
-    expect(sql).toContain('WHERE mtcw.tag_label = ?');
-    expect(norm(sql)).toContain(') OR ('); // OR-bucket for b/c
-    expect(params).toEqual(['a', 'b', 'c']); // drive a, then EXISTS b, c
+    expect(sql).toContain('WHERE mtcw.tag_label IN (?, ?, ?)');
+    expect(params).toEqual(['a', 'b', 'c']);
+  });
+
+  it('mixed AND/OR connectors fall back to a left-to-right media scan', () => {
+    // [a, b(OR), c(AND)] reads "(a OR b) AND c".
+    const { sql } = buildMediaQuery(
+      [
+        { type: 'tag', value: 'a', exclude: false },
+        { type: 'tag', value: 'b', exclude: false, join: 'OR' },
+        { type: 'tag', value: 'c', exclude: false, join: 'AND' },
+      ],
+      'AND'
+    );
+    expect(sql).toContain('FROM media');
+    expect(norm(sql)).toContain(') OR ('); // a OR b
+    expect(norm(sql)).toContain(') AND ('); // (...) AND c
   });
 
   it('an OR bucket mixing tags with a non-tag falls back to a media scan', () => {

--- a/src/__tests__/query-sql.test.ts
+++ b/src/__tests__/query-sql.test.ts
@@ -8,7 +8,7 @@ describe('buildMediaQuery', () => {
   it('returns base query with no predicates', () => {
     const { sql, params } = buildMediaQuery([], 'AND');
     expect(norm(sql)).toBe(
-      norm('SELECT media.path, media.description, media.elo, media.height, media.width FROM media')
+      norm('SELECT media.path, media.description, media.elo, media.height, media.width, NULL AS weight, NULL AS tag_label, NULL AS time_stamp, NULL AS created_at FROM media')
     );
     expect(params).toEqual([]);
   });
@@ -18,7 +18,7 @@ describe('buildMediaQuery', () => {
     const { sql, params } = buildMediaQuery(preds, 'AND');
     expect(sql).toContain('EXISTS');
     expect(sql).toContain('mtc.tag_label = ?');
-    expect(params).toEqual(['portrait']);
+    expect(params).toEqual(['portrait', 'portrait']);
   });
 
   it('builds exclude tag with NOT EXISTS', () => {
@@ -88,7 +88,7 @@ describe('buildMediaQuery', () => {
     );
     expect(norm(sql)).toContain(') AND ((');
     expect(norm(sql)).toContain(') OR (');
-    expect(params).toEqual(['a', 'b', 'c']);
+    expect(params).toEqual(['a', 'a', 'b', 'c']);
   });
 
   it('per-predicate join overrides the mode argument', () => {
@@ -100,5 +100,25 @@ describe('buildMediaQuery', () => {
       'AND'
     );
     expect(norm(sql)).toContain(') OR (');
+  });
+
+  it('LEFT JOINs media_tag_by_category for an include-tag query', () => {
+    const { sql, params } = buildMediaQuery(
+      [{ type: 'tag', value: 'cat', exclude: false }],
+      'AND'
+    );
+    expect(sql).toContain('LEFT JOIN media_tag_by_category mtcw');
+    expect(sql).toContain('mtcw.time_stamp AS time_stamp');
+    expect(sql).toContain('ORDER BY mtcw.weight');
+    expect(params[0]).toBe('cat'); // join param first
+  });
+
+  it('selects NULL tag columns and no join when there is no include tag', () => {
+    const { sql } = buildMediaQuery(
+      [{ type: 'path', value: 'x', exclude: false }],
+      'AND'
+    );
+    expect(sql).toContain('NULL AS weight');
+    expect(sql).not.toContain('LEFT JOIN');
   });
 });

--- a/src/__tests__/query-sql.test.ts
+++ b/src/__tests__/query-sql.test.ts
@@ -13,12 +13,16 @@ describe('buildMediaQuery', () => {
     expect(params).toEqual([]);
   });
 
-  it('builds an include tag predicate with EXISTS', () => {
+  it('drives a single include-tag query from the indexed tag table (no media scan)', () => {
     const preds: Predicate[] = [{ type: 'tag', value: 'portrait', exclude: false }];
     const { sql, params } = buildMediaQuery(preds, 'AND');
-    expect(sql).toContain('EXISTS');
-    expect(sql).toContain('mtc.tag_label = ?');
-    expect(params).toEqual(['portrait', 'portrait']);
+    // Fast path: FROM media_tag_by_category filtered by tag_label, not a full
+    // `media` scan with a correlated EXISTS subquery.
+    expect(sql).toContain('FROM media_tag_by_category mtcw');
+    expect(sql).toContain('WHERE mtcw.tag_label = ?');
+    expect(sql).not.toContain('EXISTS');
+    expect(sql).toContain('ORDER BY mtcw.weight');
+    expect(params).toEqual(['portrait']);
   });
 
   it('builds exclude tag with NOT EXISTS', () => {
@@ -58,26 +62,32 @@ describe('buildMediaQuery', () => {
     expect(norm(sql)).toContain(') OR (');
   });
 
-  it('joins clauses with AND in AND mode', () => {
-    const { sql } = buildMediaQuery(
+  it('drives from the first AND-tag and adds other tags as conjunct EXISTS', () => {
+    const { sql, params } = buildMediaQuery(
       [
         { type: 'tag', value: 'a', exclude: false },
         { type: 'tag', value: 'b', exclude: false },
       ],
       'AND'
     );
-    expect(norm(sql)).toContain(') AND (');
+    expect(sql).toContain('FROM media_tag_by_category mtcw');
+    expect(sql).toContain('WHERE mtcw.tag_label = ?');
+    expect(sql).toContain('AND (EXISTS');
+    expect(sql).toContain('mtc.tag_label = ?'); // EXISTS for tag b
+    expect(params).toEqual(['a', 'b']); // drive tag a, then EXISTS b
   });
 
-  it('treats EXCLUSIVE like AND for SQL joining', () => {
-    const a = norm(buildMediaQuery(
+  it('treats EXCLUSIVE like AND (drives from first tag)', () => {
+    const { sql, params } = buildMediaQuery(
       [{ type: 'tag', value: 'a', exclude: false }, { type: 'tag', value: 'b', exclude: false }],
       'EXCLUSIVE'
-    ).sql);
-    expect(a).toContain(') AND (');
+    );
+    expect(sql).toContain('FROM media_tag_by_category mtcw');
+    expect(sql).toContain('AND (EXISTS');
+    expect(params).toEqual(['a', 'b']);
   });
 
-  it('faceted: per-predicate join buckets AND-required with OR-group', () => {
+  it('faceted: drives from the AND-tag and ORs the OR-bucket', () => {
     const { sql, params } = buildMediaQuery(
       [
         { type: 'tag', value: 'a', exclude: false, join: 'AND' },
@@ -86,31 +96,34 @@ describe('buildMediaQuery', () => {
       ],
       'AND'
     );
-    expect(norm(sql)).toContain(') AND ((');
-    expect(norm(sql)).toContain(') OR (');
-    expect(params).toEqual(['a', 'a', 'b', 'c']);
+    expect(sql).toContain('FROM media_tag_by_category mtcw');
+    expect(sql).toContain('WHERE mtcw.tag_label = ?');
+    expect(norm(sql)).toContain(') OR ('); // OR-bucket for b/c
+    expect(params).toEqual(['a', 'b', 'c']); // drive a, then EXISTS b, c
   });
 
-  it('per-predicate join overrides the mode argument', () => {
-    const { sql } = buildMediaQuery(
+  it('OR-only tags fall back to a media scan with an OR group', () => {
+    const { sql, params } = buildMediaQuery(
       [
         { type: 'tag', value: 'a', exclude: false, join: 'OR' },
         { type: 'tag', value: 'b', exclude: false, join: 'OR' },
       ],
       'AND'
     );
+    // Cannot drive from an optional OR-tag — fall back to FROM media + EXISTS.
+    expect(sql).toContain('FROM media LEFT JOIN media_tag_by_category mtcw');
     expect(norm(sql)).toContain(') OR (');
   });
 
-  it('LEFT JOINs media_tag_by_category for an include-tag query', () => {
+  it('exposes weight/tag/timestamp columns for an include-tag query', () => {
     const { sql, params } = buildMediaQuery(
       [{ type: 'tag', value: 'cat', exclude: false }],
       'AND'
     );
-    expect(sql).toContain('LEFT JOIN media_tag_by_category mtcw');
     expect(sql).toContain('mtcw.time_stamp AS time_stamp');
+    expect(sql).toContain('mtcw.weight AS weight');
     expect(sql).toContain('ORDER BY mtcw.weight');
-    expect(params[0]).toBe('cat'); // join param first
+    expect(params[0]).toBe('cat');
   });
 
   it('selects NULL tag columns and no join when there is no include tag', () => {

--- a/src/__tests__/session-restore-query.test.ts
+++ b/src/__tests__/session-restore-query.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression test for unified-query persistence: a restored session whose only
+ * predicate is a NON-tag filter (path / category / description / hash) must
+ * still be recognised as a filtered query at boot. Previously the boot routing
+ * keyed solely on persisted tags, so a path-only query was misread as "no
+ * filter", routed to the filesystem view, and the predicate was wiped.
+ */
+// Mock the platform layer so ts-jest doesn't type-check platform.ts (which
+// carries pre-existing type errors the webpack transpile-only build ignores).
+// useSessionStore only needs `sessionStore` from it at runtime.
+jest.mock('../renderer/platform', () => ({
+  sessionStore: {
+    getAll: async () => null,
+    set: async () => undefined,
+    setMany: async () => undefined,
+    flush: async () => undefined,
+    clear: async () => undefined,
+    clearKeys: async () => undefined,
+  },
+}));
+
+import {
+  setSessionValue,
+  hasPersistedTags,
+  hasPersistedQuery,
+  clearSession,
+} from '../renderer/hooks/useSessionStore';
+
+const makeQuery = (predicates: any[], tags: string[] = []) =>
+  ({
+    dbQuery: { tags },
+    query: { predicates },
+    mostRecentTag: '',
+    mostRecentCategory: '',
+    textFilter: '',
+  } as any);
+
+describe('session restore routing guards', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    clearSession();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('recognises a path-only predicate query as a persisted filter', () => {
+    setSessionValue(
+      'query',
+      makeQuery([
+        { id: '1', type: 'path', value: 'Some/Folder', exclude: false, join: 'AND' },
+      ])
+    );
+    // The legacy tags-only guard misses non-tag predicates...
+    expect(hasPersistedTags()).toBe(false);
+    // ...but the query guard catches them, so boot routes to the DB view.
+    expect(hasPersistedQuery()).toBe(true);
+  });
+
+  it('returns false for an empty persisted query', () => {
+    setSessionValue('query', makeQuery([]));
+    expect(hasPersistedQuery()).toBe(false);
+    expect(hasPersistedTags()).toBe(false);
+  });
+
+  it('still recognises tag queries via both guards', () => {
+    setSessionValue(
+      'query',
+      makeQuery(
+        [{ id: '1', type: 'tag', value: 'blonde', exclude: false, join: 'AND' }],
+        ['blonde']
+      )
+    );
+    expect(hasPersistedTags()).toBe(true);
+    expect(hasPersistedQuery()).toBe(true);
+  });
+
+  it('returns false when nothing is persisted', () => {
+    clearSession();
+    expect(hasPersistedQuery()).toBe(false);
+    expect(hasPersistedTags()).toBe(false);
+  });
+});

--- a/src/__tests__/tag-search-service.test.ts
+++ b/src/__tests__/tag-search-service.test.ts
@@ -1,0 +1,48 @@
+// Tests for the shared tag-search singleton. In jsdom there is no Web Worker,
+// so the service exercises its synchronous Fuse fallback — which is exactly the
+// path we want to assert the index-idempotency guard and the minimum-query-length
+// gate on. Both guards exist to keep the 176K-tag library from (a) being
+// re-cloned to the worker on every consumer's first search and (b) being fuzzy
+// scanned for trivially-short, match-everything queries.
+import {
+  indexTags,
+  searchTags,
+  type TagConcept,
+} from '../renderer/search/tag-search-service';
+
+const TAGS: TagConcept[] = [
+  { label: 'blonde_hair', category: 'Suggested', weight: 0 },
+  { label: 'blue_eyes', category: 'Suggested', weight: 0 },
+  { label: 'Some Artist', category: 'Artists', weight: 0 },
+];
+
+describe('tag-search-service', () => {
+  it('rebuilds the index only when the source reference changes', () => {
+    const ref = [...TAGS];
+    // First time with a fresh reference builds the index.
+    expect(indexTags(ref)).toBe(true);
+    // Same reference again is a no-op — this is what stops every consumer
+    // (warmer, taxonomy, palette) from re-cloning the full tag set to the
+    // worker on its first search.
+    expect(indexTags(ref)).toBe(false);
+    // A genuinely new reference (e.g. after a mutation refetch) rebuilds.
+    expect(indexTags([...TAGS])).toBe(true);
+  });
+
+  it('returns no matches below the minimum query length', (done) => {
+    indexTags([...TAGS]);
+    searchTags('b', 10, (items) => {
+      expect(items).toEqual([]);
+      done();
+    });
+  });
+
+  it('searches once the query reaches the minimum length', (done) => {
+    indexTags([...TAGS]);
+    searchTags('blo', 10, (items) => {
+      expect(items.length).toBeGreaterThan(0);
+      expect(items.some((t) => t.label === 'blonde_hair')).toBe(true);
+      done();
+    });
+  });
+});

--- a/src/__tests__/video-frame.test.ts
+++ b/src/__tests__/video-frame.test.ts
@@ -3,6 +3,8 @@ import {
   snapFrameRate,
   frameStep,
   pixelToTime,
+  selectDisplayTime,
+  coalescedSeekTarget,
   DEFAULT_FPS,
 } from '../renderer/video-frame';
 
@@ -94,5 +96,41 @@ describe('pixelToTime', () => {
   it('returns 0 for invalid bar width or duration', () => {
     expect(pixelToTime(50, 0, 2)).toBe(0);
     expect(pixelToTime(50, 100, 0)).toBe(0);
+  });
+});
+
+describe('selectDisplayTime', () => {
+  it('uses the live drag position while dragging', () => {
+    expect(selectDisplayTime(true, 3.5, 1.0)).toBe(3.5);
+  });
+
+  it('falls back to actual time when dragging but no drag value yet', () => {
+    expect(selectDisplayTime(true, null, 1.0)).toBe(1.0);
+  });
+
+  it('uses actual time when not dragging', () => {
+    expect(selectDisplayTime(false, 3.5, 1.0)).toBe(1.0);
+  });
+
+  it('treats a 0 drag time as a real value, not absent', () => {
+    expect(selectDisplayTime(true, 0, 5.0)).toBe(0);
+  });
+});
+
+describe('coalescedSeekTarget', () => {
+  it('seeks to the pending target when idle and far enough away', () => {
+    expect(coalescedSeekTarget(2.0, false, 1.0)).toBe(2.0);
+  });
+
+  it('waits (null) while a seek is already in flight', () => {
+    expect(coalescedSeekTarget(2.0, true, 1.0)).toBeNull();
+  });
+
+  it('does nothing when there is no pending target', () => {
+    expect(coalescedSeekTarget(null, false, 1.0)).toBeNull();
+  });
+
+  it('does nothing when already at the target (within tolerance)', () => {
+    expect(coalescedSeekTarget(1.0005, false, 1.0)).toBeNull();
   });
 });

--- a/src/__tests__/video-frame.test.ts
+++ b/src/__tests__/video-frame.test.ts
@@ -1,0 +1,98 @@
+import {
+  estimateFrameRate,
+  snapFrameRate,
+  frameStep,
+  pixelToTime,
+  DEFAULT_FPS,
+} from '../renderer/video-frame';
+
+describe('snapFrameRate', () => {
+  it('snaps near-common estimates to the canonical rate', () => {
+    expect(snapFrameRate(29.95)).toBe(29.97);
+    expect(snapFrameRate(30.2)).toBe(30);
+    expect(snapFrameRate(23.9)).toBe(23.976);
+    expect(snapFrameRate(59.8)).toBe(59.94);
+  });
+
+  it('keeps a raw (rounded) estimate when far from any common rate', () => {
+    // 47fps is >2% away from 48?/50 — no common rate near it, keep raw.
+    expect(snapFrameRate(47)).toBe(47);
+  });
+
+  it('returns 0 for invalid input', () => {
+    expect(snapFrameRate(0)).toBe(0);
+    expect(snapFrameRate(-5)).toBe(0);
+    expect(snapFrameRate(Infinity)).toBe(0);
+  });
+});
+
+describe('estimateFrameRate', () => {
+  it('estimates fps from evenly spaced mediaTime samples', () => {
+    const t = [0, 1 / 30, 2 / 30, 3 / 30, 4 / 30, 5 / 30];
+    expect(estimateFrameRate(t)).toBe(30);
+  });
+
+  it('discards loop-reset (backward) deltas from short looping videos', () => {
+    // Plays to ~1s then loops back to 0 — the negative delta must be ignored.
+    const t = [0.9, 0.9 + 1 / 30, 0.9 + 2 / 30, 0, 1 / 30, 2 / 30, 3 / 30];
+    expect(estimateFrameRate(t)).toBe(30);
+  });
+
+  it('returns 0 when there are not enough usable samples', () => {
+    expect(estimateFrameRate([])).toBe(0);
+    expect(estimateFrameRate([0])).toBe(0);
+    expect(estimateFrameRate([0, 0.033])).toBe(0);
+  });
+
+  it('detects 60fps', () => {
+    const t = Array.from({ length: 8 }, (_, i) => i / 60);
+    expect(estimateFrameRate(t)).toBe(60);
+  });
+});
+
+describe('frameStep', () => {
+  it('steps forward one frame at the given fps', () => {
+    expect(frameStep(1.0, 30, 1, 10)).toBeCloseTo(1 + 1 / 30, 6);
+  });
+
+  it('steps backward one frame', () => {
+    expect(frameStep(1.0, 30, -1, 10)).toBeCloseTo(1 - 1 / 30, 6);
+  });
+
+  it('falls back to DEFAULT_FPS when frameRate is unknown', () => {
+    expect(frameStep(1.0, 0, 1, 10)).toBeCloseTo(1 + 1 / DEFAULT_FPS, 6);
+    expect(frameStep(1.0, NaN, 1, 10)).toBeCloseTo(1 + 1 / DEFAULT_FPS, 6);
+  });
+
+  it('clamps at the lower bound', () => {
+    expect(frameStep(0, 30, -1, 10)).toBe(0);
+  });
+
+  it('never seeks to or past the duration', () => {
+    const result = frameStep(9.99, 30, 1, 10);
+    expect(result).toBeLessThan(10);
+  });
+
+  it('returns 0 when duration is unknown', () => {
+    expect(frameStep(5, 30, 1, 0)).toBe(0);
+  });
+});
+
+describe('pixelToTime', () => {
+  it('maps pixels to fractional time without rounding to whole seconds', () => {
+    // The regression that motivated this work: a quarter-way drag on a 1s
+    // video must yield 0.25s, not 0s.
+    expect(pixelToTime(25, 100, 1)).toBeCloseTo(0.25, 6);
+    expect(pixelToTime(50, 100, 2)).toBeCloseTo(1.0, 6);
+  });
+
+  it('clamps offsets outside the bar', () => {
+    expect(pixelToTime(-10, 100, 2)).toBe(0);
+    expect(pixelToTime(150, 100, 2)).toBe(2);
+  });
+
+  it('returns 0 for invalid bar width or duration', () => {
+    expect(pixelToTime(50, 0, 2)).toBe(0);
+    expect(pixelToTime(50, 100, 0)).toBe(0);
+  });
+});

--- a/src/__tests__/video-frame.test.ts
+++ b/src/__tests__/video-frame.test.ts
@@ -5,6 +5,7 @@ import {
   pixelToTime,
   selectDisplayTime,
   coalescedSeekTarget,
+  seekBy,
   DEFAULT_FPS,
 } from '../renderer/video-frame';
 
@@ -114,6 +115,22 @@ describe('selectDisplayTime', () => {
 
   it('treats a 0 drag time as a real value, not absent', () => {
     expect(selectDisplayTime(true, 0, 5.0)).toBe(0);
+  });
+});
+
+describe('seekBy', () => {
+  it('skips forward and backward by the given seconds', () => {
+    expect(seekBy(20, 10, 100)).toBe(30);
+    expect(seekBy(20, -10, 100)).toBe(10);
+  });
+
+  it('clamps to the start and end', () => {
+    expect(seekBy(5, -10, 100)).toBe(0);
+    expect(seekBy(95, 10, 100)).toBe(100);
+  });
+
+  it('returns 0 when duration is unknown', () => {
+    expect(seekBy(5, 10, 0)).toBe(0);
   });
 });
 

--- a/src/__tests__/warm-tag-search-gating.test.tsx
+++ b/src/__tests__/warm-tag-search-gating.test.tsx
@@ -1,0 +1,85 @@
+import { render, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Regression test for the startup handler-registration race.
+//
+// Bug: useWarmTagSearch fired its `load-all-tags` IPC fetch with `enabled: true`
+// the moment it mounted. The hook mounts during app boot, before the main
+// process finishes `load-db` and registers the taxonomy IPC handlers, so the
+// fetch failed with "No handler registered for 'load-all-tags'" on essentially
+// every launch (visible as renderer:invoke:load-all-tags failures in
+// app-log.jsonl). React Query retried after the DB became ready, so it was
+// benign — but it logged an error every time.
+//
+// The fix gates the fetch on `initSessionId`, which the state machine only
+// assigns once it reaches its post-DB `init` state. Empty id (pre-DB) => no
+// fetch; real id (post-DB, handlers registered) => fetch.
+
+let mockInitSessionId = '';
+const mockInvoke = jest.fn(async (..._args: any[]) => [] as unknown[]);
+const mockIndexTags = jest.fn();
+
+jest.mock('@xstate/react', () => ({
+  useSelector: (_service: any, selector: any) =>
+    selector({ context: { initSessionId: mockInitSessionId } }),
+}));
+
+jest.mock('../renderer/state', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    GlobalStateContext: React.createContext({ libraryService: {} }),
+  };
+});
+
+jest.mock('../renderer/platform', () => ({
+  __esModule: true,
+  invoke: (...args: any[]) => mockInvoke(...args),
+}));
+
+jest.mock('../renderer/search/tag-search-service', () => ({
+  __esModule: true,
+  indexTags: (...args: any[]) => mockIndexTags(...args),
+}));
+
+import { useWarmTagSearch } from '../renderer/hooks/useWarmTagSearch';
+
+function Harness() {
+  useWarmTagSearch();
+  return null;
+}
+
+function renderHarness() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <Harness />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  mockInvoke.mockClear();
+  mockIndexTags.mockClear();
+});
+
+describe('useWarmTagSearch startup gating', () => {
+  it('does not fetch all-tags before the DB is ready (empty initSessionId)', async () => {
+    mockInitSessionId = '';
+    renderHarness();
+
+    // Give React Query a tick to (not) schedule the disabled query.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it('fetches all-tags once the DB is ready (initSessionId set)', async () => {
+    mockInitSessionId = 'session-123';
+    renderHarness();
+
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledTimes(1));
+    expect(mockInvoke).toHaveBeenCalledWith('load-all-tags', []);
+  });
+});

--- a/src/main/async-timeout.ts
+++ b/src/main/async-timeout.ts
@@ -1,0 +1,49 @@
+// Wrap a promise so it can't hang forever. Used to bound fallible async loads
+// (DB open, filesystem scans) so a stalled operation surfaces as a rejection —
+// which the renderer's XState machine can route through its onError transitions
+// — instead of stranding the app on a permanent loading spinner.
+
+export class TimeoutError extends Error {
+  readonly code = 'ETIMEDOUT';
+
+  constructor(label: string, ms: number) {
+    super(`${label} timed out after ${ms}ms`);
+    this.name = 'TimeoutError';
+  }
+}
+
+/**
+ * Rejects with TimeoutError if `promise` doesn't settle within `ms`. The
+ * underlying work is NOT cancelled (JS can't cancel a promise) — callers that
+ * own a cancellable resource (e.g. a child process) should pass `onTimeout` to
+ * clean it up. The timer is always cleared so the process can exit cleanly.
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+  onTimeout?: () => void
+): Promise<T> {
+  if (!Number.isFinite(ms) || ms <= 0) return promise;
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      try {
+        onTimeout?.();
+      } catch {
+        // cleanup best-effort
+      }
+      reject(new TimeoutError(label, ms));
+    }, ms);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
+  });
+}

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -12,15 +12,30 @@ const now = (): number => {
 export class Database {
   private db: sqlite3.Database;
 
-  constructor(dbPath: string) {
-    this.db = new sqlite3.Database(dbPath, (err) => {
-      if (err) {
-        console.error('Error connecting to the database:', err);
-      } else {
-        console.log('Connected to the database');
-        this.db.run('PRAGMA journal_mode = WAL');
-      }
-    });
+  // Resolves once the connection is open and its startup pragmas are applied;
+  // rejects if the file can't be opened. Callers (see load-db in main.ts) must
+  // await this before running migrations so busy_timeout is in effect first.
+  readonly ready: Promise<void>;
+
+  constructor(dbPath: string, busyTimeoutMs = 5000) {
+    this.db = new sqlite3.Database(dbPath);
+    this.ready = this.applyStartupPragmas(busyTimeoutMs);
+  }
+
+  private async applyStartupPragmas(busyTimeoutMs: number): Promise<void> {
+    // busy_timeout needs no lock and must come first: it makes SQLite wait out
+    // a write lock held by the Go media-server (which also opens dream.sqlite)
+    // instead of failing instantly with SQLITE_BUSY and stranding startup.
+    await this.run(
+      `PRAGMA busy_timeout = ${busyTimeoutMs}`,
+      [],
+      'pragma:busy_timeout'
+    );
+    // WAL improves read/write concurrency between the two processes. Switching
+    // journal mode briefly needs an exclusive lock, so it benefits from the
+    // busy_timeout set above. Awaited (via `ready`) rather than fire-and-forget.
+    await this.run('PRAGMA journal_mode = WAL', [], 'pragma:journal_mode');
+    console.log('Connected to the database');
   }
 
   run(

--- a/src/main/db-retry.ts
+++ b/src/main/db-retry.ts
@@ -1,0 +1,80 @@
+// Recovery helpers for transient SQLite lock contention.
+//
+// The desktop app and the Go media-server can hold the same `dream.sqlite`
+// open at once. When the server holds a write lock while the app is starting,
+// SQLite returns SQLITE_BUSY / SQLITE_LOCKED. These helpers let startup wait
+// the lock out (busy_timeout, applied in database.ts) and retry instead of
+// failing hard and stranding the renderer on a never-loading screen.
+
+/**
+ * True when an error represents a transient SQLite lock (SQLITE_BUSY /
+ * SQLITE_LOCKED), which is safe to wait out and retry. Other errors (missing
+ * table, disk full, corruption) are not retryable and must surface.
+ */
+export function isDatabaseLockedError(err: unknown): boolean {
+  if (!err) return false;
+  const code = (err as { code?: unknown }).code;
+  if (code === 'SQLITE_BUSY' || code === 'SQLITE_LOCKED') return true;
+  const message = (err as { message?: unknown }).message;
+  if (typeof message === 'string') {
+    return (
+      message.includes('SQLITE_BUSY') ||
+      message.includes('SQLITE_LOCKED') ||
+      message.includes('database is locked') ||
+      message.includes('database table is locked')
+    );
+  }
+  return false;
+}
+
+export interface RetryOptions {
+  /** Number of retries after the first attempt. */
+  retries: number;
+  /** Decides whether a thrown error is worth retrying. */
+  isRetryable: (err: unknown) => boolean;
+  /** Base backoff in ms; doubles each retry. Defaults to 250ms. */
+  baseDelayMs?: number;
+  /** Injectable sleep so tests stay deterministic. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Optional hook for logging each retry. */
+  onRetry?: (err: unknown, attempt: number, delayMs: number) => void;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * Runs `factory`, retrying with exponential backoff while it throws a
+ * retryable error. Re-throws immediately on a non-retryable error, and
+ * re-throws the last error once retries are exhausted.
+ */
+export async function retryAsync<T>(
+  factory: () => Promise<T>,
+  options: RetryOptions
+): Promise<T> {
+  const {
+    retries,
+    isRetryable,
+    baseDelayMs = 250,
+    sleep = defaultSleep,
+    onRetry,
+  } = options;
+
+  let attempt = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      return await factory();
+    } catch (err) {
+      if (attempt >= retries || !isRetryable(err)) {
+        throw err;
+      }
+      const delayMs = baseDelayMs * 2 ** attempt;
+      onRetry?.(err, attempt + 1, delayMs);
+      attempt += 1;
+      await sleep(delayMs);
+    }
+  }
+}

--- a/src/main/errorLog.ts
+++ b/src/main/errorLog.ts
@@ -1,0 +1,150 @@
+import { app } from 'electron';
+import fs from 'fs';
+import path from 'path';
+
+// Append-only JSONL log of app-level errors and data-load failures, written
+// from the main process. This is deliberately separate from query-log.jsonl
+// (which records every DB query): this file is for the things that strand the
+// app — uncaught exceptions, unhandled rejections, IPC handler failures, and
+// load lifecycle events (load-db / load-files start / timeout / error).
+//
+// The user reproduces the hang, then ships app-log.jsonl back; the last lines
+// reveal which load never completed (e.g. a `load-files` start with no matching
+// done, or a `load-db` timeout) instead of leaving us guessing.
+//
+// Lives at <userData>/app-log.jsonl. Logging must never throw.
+
+export type LogLevel = 'error' | 'warn' | 'info';
+
+let cachedLogPath: string | null = null;
+let stream: fs.WriteStream | null = null;
+let enabled = true;
+
+function resolveLogPath(): string {
+  if (cachedLogPath) return cachedLogPath;
+  try {
+    cachedLogPath = path.join(app.getPath('userData'), 'app-log.jsonl');
+  } catch {
+    // Called before app is ready (shouldn't happen, but never crash on it).
+    cachedLogPath = path.join(process.cwd(), 'app-log.jsonl');
+  }
+  return cachedLogPath;
+}
+
+function getStream(): fs.WriteStream | null {
+  if (stream) return stream;
+  try {
+    stream = fs.createWriteStream(resolveLogPath(), { flags: 'a' });
+    stream.on('error', (e) => {
+      // eslint-disable-next-line no-console
+      console.error('[errorLog] write stream error', e);
+      stream = null;
+    });
+    return stream;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('[errorLog] failed to open log file', e);
+    return null;
+  }
+}
+
+// Turn an arbitrary thrown value into a JSON-serializable shape. Errors don't
+// serialize via JSON.stringify (message/stack are non-enumerable), so pull the
+// useful fields out explicitly.
+export function serializeError(err: unknown): unknown {
+  if (err == null) return null;
+  if (err instanceof Error) {
+    const out: Record<string, unknown> = {
+      name: err.name,
+      message: err.message,
+      stack: err.stack,
+    };
+    const code = (err as { code?: unknown }).code;
+    if (code !== undefined) out.code = code;
+    const errno = (err as { errno?: unknown }).errno;
+    if (errno !== undefined) out.errno = errno;
+    return out;
+  }
+  if (typeof err === 'object') {
+    try {
+      return JSON.parse(JSON.stringify(err));
+    } catch {
+      return { value: String(err) };
+    }
+  }
+  return { value: String(err) };
+}
+
+export interface LogEntryInput {
+  level?: LogLevel;
+  /** Where it came from, e.g. 'main:uncaughtException', 'ipc:load-files'. */
+  scope: string;
+  message: string;
+  data?: unknown;
+  /** A thrown value; serialized into the entry. */
+  error?: unknown;
+}
+
+export function logEvent(entry: LogEntryInput): void {
+  if (!enabled) return;
+  try {
+    const s = getStream();
+    if (!s) return;
+    const line =
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        source: 'electron',
+        level: entry.level ?? 'error',
+        scope: entry.scope,
+        message: entry.message,
+        data: entry.data ?? null,
+        error: entry.error !== undefined ? serializeError(entry.error) : null,
+      }) + '\n';
+    s.write(line);
+  } catch {
+    // Never let logging break the app.
+  }
+}
+
+export function setAppLogEnabled(v: boolean): void {
+  enabled = v;
+}
+
+export function getAppLogPath(): string {
+  return resolveLogPath();
+}
+
+export function flushAppLog(): Promise<void> {
+  return new Promise((resolve) => {
+    const s = stream;
+    if (!s) {
+      resolve();
+      return;
+    }
+    s.end(() => {
+      stream = null;
+      resolve();
+    });
+  });
+}
+
+/**
+ * Installs process-level handlers so nothing crashes or hangs silently. Safe to
+ * call once at main startup. Logs to the file and still logs to console.
+ */
+export function installGlobalErrorHandlers(): void {
+  process.on('uncaughtException', (error) => {
+    // eslint-disable-next-line no-console
+    console.error('Uncaught exception in main process:', error);
+    logEvent({ scope: 'main:uncaughtException', message: 'Uncaught exception', error });
+  });
+  process.on('unhandledRejection', (reason) => {
+    // eslint-disable-next-line no-console
+    console.error('Unhandled promise rejection in main process:', reason);
+    logEvent({
+      scope: 'main:unhandledRejection',
+      message: 'Unhandled promise rejection',
+      error: reason,
+    });
+  });
+}

--- a/src/main/load-files.ts
+++ b/src/main/load-files.ts
@@ -5,8 +5,47 @@ import { IpcMainInvokeEvent } from 'electron';
 import { insertBulkMedia } from './media';
 import fsPromises from 'fs/promises';
 import os from 'os';
-import { spawn } from 'child_process';
+import { spawn, ChildProcess } from 'child_process';
 import { isArchivePath, extractArchive } from './archives';
+import { logEvent } from './errorLog';
+
+// A directory scan delegates to an external process (PowerShell on Windows,
+// `find` on macOS). If that child stalls — a disconnected network drive, a
+// wedged shell — it can emit nothing and never close, leaving the scan promise
+// pending forever and stranding the renderer on a permanent loading spinner.
+// This watchdog kills a child that has produced no output for too long so the
+// promise always settles (with whatever partial results we have).
+const SCAN_INACTIVITY_MS = 30_000;
+
+function watchChildInactivity(
+  child: ChildProcess,
+  label: string,
+  rootDir: string,
+  onStall: () => void
+): { bump: () => void; clear: () => void } {
+  let last = Date.now();
+  const interval = setInterval(() => {
+    if (Date.now() - last < SCAN_INACTIVITY_MS) return;
+    clearInterval(interval);
+    logEvent({
+      scope: 'ipc:load-files',
+      message: `${label} produced no output for ${SCAN_INACTIVITY_MS}ms; killing stalled child`,
+      data: { pid: child.pid, rootDir },
+    });
+    try {
+      child.kill();
+    } catch {
+      // best-effort
+    }
+    onStall();
+  }, 5000);
+  return {
+    bump: () => {
+      last = Date.now();
+    },
+    clear: () => clearInterval(interval),
+  };
+}
 
 type File = {
   path: string;
@@ -134,8 +173,21 @@ async function listFilesFastDarwin(
     console.log('[fastest-mac] child pid:', child.pid);
 
     let buffer = '';
-    let filesQueued: string[] = [];
+    const filesQueued: string[] = [];
     let activeStats = 0;
+    let settled = false;
+    // Control holder breaks the settle<->watchdog cycle so watchdog can be const.
+    const ctl: { settle: () => void } = { settle: () => undefined };
+    const watchdog = watchChildInactivity(child, 'find scan', rootDir, () =>
+      ctl.settle()
+    );
+    ctl.settle = () => {
+      if (settled) return;
+      settled = true;
+      watchdog.clear();
+      resolve();
+    };
+    const settle = ctl.settle;
     const MAX_CONC_STATS = needMtime ? 32 : 0;
 
     const trySchedule = () => {
@@ -170,6 +222,7 @@ async function listFilesFastDarwin(
     };
 
     child.stdout.on('data', (chunk: Buffer) => {
+      watchdog.bump();
       buffer += chunk.toString('utf8');
       let idx;
       while ((idx = buffer.indexOf('\0')) !== -1) {
@@ -183,13 +236,19 @@ async function listFilesFastDarwin(
     });
     const finalize = () => {
       const onIdle = () => {
-        if (activeStats === 0) resolve();
+        if (activeStats === 0) settle();
         else setTimeout(onIdle, 10);
       };
       onIdle();
     };
     child.on('error', (err) => {
       console.log('[fastest-mac] child error:', err);
+      logEvent({
+        scope: 'ipc:load-files',
+        message: 'find scan child error',
+        data: { rootDir },
+        error: err,
+      });
       finalize();
     });
     child.on('close', () => {
@@ -229,7 +288,21 @@ async function listFilesFastWindows(
     let buffer = '';
     let totalBytes = 0;
     let lineCount = 0;
+    let settled = false;
+    // Control holder breaks the settle<->watchdog cycle so watchdog can be const.
+    const ctl: { settle: () => void } = { settle: () => undefined };
+    const watchdog = watchChildInactivity(child, 'powershell scan', rootDir, () =>
+      ctl.settle()
+    );
+    ctl.settle = () => {
+      if (settled) return;
+      settled = true;
+      watchdog.clear();
+      resolve();
+    };
+    const settle = ctl.settle;
     child.stdout.on('data', (chunk: Buffer) => {
+      watchdog.bump();
       totalBytes += chunk.length;
       buffer += chunk.toString('utf8');
       let idx;
@@ -283,11 +356,17 @@ async function listFilesFastWindows(
         'lines:',
         lineCount
       );
-      resolve();
+      settle();
     });
     child.on('error', (err) => {
       console.log('[fastest] child error:', err);
-      resolve();
+      logEvent({
+        scope: 'ipc:load-files',
+        message: 'powershell scan child error',
+        data: { rootDir },
+        error: err,
+      });
+      settle();
     });
     child.on('close', (code, signal) => {
       flushRemainder();
@@ -297,7 +376,7 @@ async function listFilesFastWindows(
         bytes: totalBytes,
         lines: lineCount,
       });
-      resolve();
+      settle();
     });
   });
 }
@@ -350,6 +429,17 @@ export const loadFiles =
     }
 
     const effectiveRecursive = archiveExtracted ? true : recursive;
+    logEvent({
+      level: 'info',
+      scope: 'ipc:load-files',
+      message: 'load-files start',
+      data: {
+        filePath,
+        folderPath,
+        recursive: effectiveRecursive,
+        fastest: !!options.fastest,
+      },
+    });
 
     // Stream the directory and emit batches to the renderer for incremental UI updates
     const files: File[] = [];
@@ -449,6 +539,13 @@ export const loadFiles =
       db,
       sortedFiles.map((file) => file.path)
     );
+
+    logEvent({
+      level: 'info',
+      scope: 'ipc:load-files',
+      message: 'load-files done',
+      data: { total: sortedFiles.length, cursor },
+    });
 
     try {
       console.log('[loader] sending done', {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -324,6 +324,8 @@ ipcMain.handle('load-db', async (event, args) => {
   ipcMain.removeHandler('load-category-tags');
   ipcMain.removeHandler('load-all-tags');
   ipcMain.removeHandler('get-tag-count');
+  ipcMain.removeHandler('load-path-suggestions');
+  ipcMain.removeHandler('get-category-count');
   ipcMain.removeHandler('create-tag');
   ipcMain.removeHandler('create-category');
   ipcMain.removeHandler('create-assignment');
@@ -406,6 +408,8 @@ ipcMain.handle('load-db', async (event, args) => {
   ipcMain.handle('load-category-tags', taxonomyModule.loadCategoryTags(db));
   ipcMain.handle('load-all-tags', taxonomyModule.loadAllTags(db));
   ipcMain.handle('get-tag-count', taxonomyModule.getTagCount(db));
+  ipcMain.handle('load-path-suggestions', taxonomyModule.loadPathSuggestions(db));
+  ipcMain.handle('get-category-count', taxonomyModule.getCategoryCount(db));
   ipcMain.handle('create-tag', taxonomyModule.createTag(db));
   ipcMain.handle('create-category', taxonomyModule.createCategory(db));
   ipcMain.handle(

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -360,6 +360,7 @@ ipcMain.handle('load-db', async (event, args) => {
   ipcMain.removeHandler('apply-elo-ordering');
   ipcMain.removeHandler('consolidate-tag-files');
   ipcMain.removeHandler('consolidate-category-files');
+  ipcMain.removeHandler('load-media-by-query');
 
   // Dynamically import heavy modules in parallel and register handlers
   const [mediaModule, taxonomyModule, metadataModule, loadFilesModule] =
@@ -378,6 +379,7 @@ ipcMain.handle('load-db', async (event, args) => {
     'load-media-by-description-search',
     mediaModule.loadMediaByDescriptionSearch(db)
   );
+  ipcMain.handle('load-media-by-query', mediaModule.loadMediaByQuery(db));
   ipcMain.handle('update-elo', mediaModule.updateElo(db));
   ipcMain.handle('update-description', mediaModule.updateDescription(db));
   ipcMain.handle(

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -23,16 +23,14 @@ import {
 } from './sessionStore';
 import { cleanupArchives } from './archives';
 import { registerSubtitleHandlers } from './subtitles';
+import { logEvent, installGlobalErrorHandlers } from './errorLog';
+import { withTimeout } from './async-timeout';
 
 import type { Database } from './database';
 
-// Prevent hard crashes from unhandled errors in the main process
-process.on('uncaughtException', (error) => {
-  console.error('Uncaught exception in main process:', error);
-});
-process.on('unhandledRejection', (reason) => {
-  console.error('Unhandled promise rejection in main process:', reason);
-});
+// Prevent hard crashes from unhandled errors in the main process, and persist
+// them to <userData>/app-log.jsonl so field hangs/crashes can be diagnosed.
+installGlobalErrorHandlers();
 
 // Register custom protocol scheme as privileged (must be done before app ready)
 protocol.registerSchemesAsPrivileged([
@@ -71,6 +69,23 @@ class AppUpdater {
 
 let mainWindow: BrowserWindow | null = null;
 
+// Persist renderer-side errors and load failures to the same app-log.jsonl as
+// main-process errors. The renderer forwards window.onerror, unhandled
+// rejections, and failed IPC invokes here (see preload + platform.ts).
+ipcMain.on('log-event', (_event, entry) => {
+  try {
+    logEvent({
+      level: entry?.level ?? 'error',
+      scope: `renderer:${entry?.scope ?? 'unknown'}`,
+      message: String(entry?.message ?? ''),
+      data: entry?.data ?? null,
+      error: entry?.error ?? null,
+    });
+  } catch {
+    // never let logging throw
+  }
+});
+
 // Make Main Process Args available to renderer process.
 ipcMain.handle('get-main-args', () => {
   return process.argv;
@@ -104,6 +119,11 @@ ipcMain.on('minimize', async () => {
 ipcMain.on('open-external', async (event, args) => {
   const url = args[0];
   shell.openExternal(url);
+});
+
+ipcMain.on('show-item-in-folder', async (event, args) => {
+  const filePath = args[0];
+  if (filePath) shell.showItemInFolder(filePath);
 });
 
 ipcMain.on('toggle-fullscreen', async () => {
@@ -236,8 +256,64 @@ ipcMain.handle('load-db', async (event, args) => {
   await fs.promises.mkdir(dir, { recursive: true });
   // Lazy import database implementation to reduce cold-start cost
   const dbModule = await import('./database');
-  db = new dbModule.Database(dbPath);
-  await dbModule.initDB(db);
+  const { retryAsync, isDatabaseLockedError } = await import('./db-retry');
+
+  // The Go media-server can hold a write lock on the same dream.sqlite while
+  // the app starts. busy_timeout (set in Database) waits each attempt out;
+  // this retry rides out a lock that outlasts a single busy_timeout window so
+  // a transient lock never leaves the renderer stuck on a blank loading screen.
+  //
+  // Overall timeout: a lock SQLite never resolves (or a busy_timeout the driver
+  // ignores for certain lock types) would otherwise leave this promise pending
+  // forever — the renderer's loadingDB state has an onError escape but no way to
+  // react to a hang. The timeout converts that hang into a rejection so the
+  // renderer falls back to manual DB selection instead of spinning forever.
+  // 60s comfortably covers 5 retries (each up to a 5s busy_timeout + backoff).
+  const LOAD_DB_TIMEOUT_MS = 60_000;
+  logEvent({ level: 'info', scope: 'ipc:load-db', message: 'load-db start', data: { dbPath } });
+  try {
+    db = await withTimeout(
+      retryAsync(
+        async () => {
+          const candidate = new dbModule.Database(dbPath);
+          try {
+            await candidate.ready; // open + busy_timeout + WAL before migrating
+            await dbModule.initDB(candidate);
+            return candidate;
+          } catch (e) {
+            // Drop the half-open handle before retrying so we don't leak the
+            // connection or hold our own lock across attempts.
+            await candidate.close().catch(() => undefined);
+            throw e;
+          }
+        },
+        {
+          retries: 5,
+          isRetryable: isDatabaseLockedError,
+          baseDelayMs: 300,
+          onRetry: (err, attempt, delayMs) => {
+            console.warn(
+              `[load-db] database locked, retry ${attempt} in ${delayMs}ms:`,
+              (err as Error)?.message
+            );
+            logEvent({
+              level: 'warn',
+              scope: 'ipc:load-db',
+              message: `database locked, retry ${attempt} in ${delayMs}ms`,
+              error: err,
+            });
+          },
+        }
+      ),
+      LOAD_DB_TIMEOUT_MS,
+      'load-db'
+    );
+  } catch (err) {
+    // Surface to the renderer (onError -> manualSetup) and record why.
+    logEvent({ scope: 'ipc:load-db', message: 'load-db failed', data: { dbPath }, error: err });
+    throw err;
+  }
+  logEvent({ level: 'info', scope: 'ipc:load-db', message: 'load-db ready', data: { dbPath } });
   ipcMain.removeHandler('load-media-by-tags');
   ipcMain.removeHandler('refresh-library');
   ipcMain.removeHandler('load-media-by-description-search');

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -63,7 +63,19 @@ class AppUpdater {
   constructor() {
     log.transports.file.level = 'info';
     autoUpdater.logger = log;
-    autoUpdater.checkForUpdatesAndNotify();
+    // checkForUpdatesAndNotify rejects when the release has no update manifest
+    // (e.g. a 404 on latest.yml for a build published without one). That
+    // rejection is fire-and-forget here, so without this catch it surfaces as a
+    // main-process unhandledRejection on every launch. Swallow it: a failed
+    // update check is non-fatal and shouldn't pollute the error log.
+    autoUpdater.checkForUpdatesAndNotify().catch((err) => {
+      logEvent({
+        level: 'warn',
+        scope: 'main:autoUpdater',
+        message: 'update check failed',
+        error: err,
+      });
+    });
   }
 }
 

--- a/src/main/media.ts
+++ b/src/main/media.ts
@@ -8,6 +8,8 @@ import { getFileType } from '../file-types';
 import { IpcMainInvokeEvent, shell } from 'electron';
 import fs from 'fs';
 import { isNetworkPath } from './network-drive-cache';
+import { buildMediaQuery, FilteringMode } from './query-sql';
+import type { Predicate } from '../renderer/query/types';
 
 const MAX_CONCURRENT_LOCAL = 12;
 const MAX_CONCURRENT_NETWORK = 3;
@@ -301,6 +303,27 @@ const loadMediaByDescriptionSearch =
       return { library, cursor: 0 };
     } catch (error) {
       console.error('Error in loadMediaByDescriptionSearch:', error);
+      throw error;
+    }
+  };
+
+const loadMediaByQuery =
+  (db: Database) => async (_: IpcMainInvokeEvent, args: any[]) => {
+    const predicates = (args[0] || []) as Predicate[];
+    const mode = (args[1] || 'AND') as FilteringMode;
+    const { sql, params } = buildMediaQuery(predicates, mode);
+    try {
+      const mediaRows = await db.all(sql, params, 'loadMediaByQuery');
+      const library = mediaRows.map((m: any) => ({
+        path: m.path,
+        description: m.description,
+        elo: m.elo,
+        height: m.height,
+        width: m.width,
+      }));
+      return { library, cursor: 0 };
+    } catch (error) {
+      console.error('Error in loadMediaByQuery:', error);
       throw error;
     }
   };
@@ -648,6 +671,7 @@ const mergeDuplicatesByPath =
 export {
   loadMediaByTags,
   loadMediaByDescriptionSearch,
+  loadMediaByQuery,
   fetchMediaPreview,
   copyFileIntoClipboard,
   deleteMedia,

--- a/src/main/media.ts
+++ b/src/main/media.ts
@@ -316,7 +316,6 @@ const loadMediaByQuery =
       const mediaRows = await db.all(sql, params, 'loadMediaByQuery');
       const library = mediaRows.map((m: any) => ({
         path: m.path,
-        description: m.description,
         elo: m.elo,
         height: m.height,
         width: m.width,

--- a/src/main/media.ts
+++ b/src/main/media.ts
@@ -320,6 +320,10 @@ const loadMediaByQuery =
         elo: m.elo,
         height: m.height,
         width: m.width,
+        weight: m.weight ?? undefined,
+        tagLabel: m.tag_label ?? undefined,
+        timeStamp: m.time_stamp ?? undefined,
+        mtimeMs: m.created_at || 0,
       }));
       return { library, cursor: 0 };
     } catch (error) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -35,6 +35,8 @@ export type Channels =
   | 'load-category-tags'
   | 'load-all-tags'
   | 'get-tag-count'
+  | 'load-path-suggestions'
+  | 'get-category-count'
   | 'load-file-metadata'
   | 'load-gif-metadata'
   | 'load-tags-by-media-path'

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -24,6 +24,7 @@ export type Channels =
   | 'select-db'
   | 'load-db'
   | 'open-external'
+  | 'show-item-in-folder'
   | 'toggle-fullscreen'
   | 'set-always-on-top'
   | 'add-media'
@@ -68,7 +69,18 @@ export type Channels =
   | 'apply-elo-ordering'
   | 'consolidate-tag-files'
   | 'consolidate-category-files'
+  | 'log-event'
   | 'find-subtitle';
+
+// Renderer -> main error/diagnostics channel. Fire-and-forget; persisted to
+// <userData>/app-log.jsonl alongside main-process errors.
+export interface RendererLogEntry {
+  level?: 'error' | 'warn' | 'info';
+  scope: string;
+  message: string;
+  data?: unknown;
+  error?: unknown;
+}
 
 const loadMediaFromDB = async (
   tags: string[],
@@ -160,6 +172,14 @@ const getGifMetadata = async (filePath: string) => {
 
 contextBridge.exposeInMainWorld('electron', {
   getPathForFile: (file: File) => webUtils.getPathForFile(file),
+  // Forward renderer errors/load failures to the main-process file logger.
+  logEvent: (entry: RendererLogEntry) => {
+    try {
+      ipcRenderer.send('log-event', entry);
+    } catch {
+      // never let logging throw
+    }
+  },
   loadMediaFromDB,
   loadMediaByDescriptionSearch,
   fetchTagPreview,

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -103,6 +103,11 @@ const loadMediaByDescriptionSearch = async (
   return files;
 };
 
+const loadMediaByQuery = async (predicates: unknown[], mode: string) => {
+  const files = await ipcRenderer.invoke('load-media-by-query', [predicates, mode]);
+  return files;
+};
+
 const fetchTagPreview = async (tag: string) => {
   const results = await ipcRenderer.invoke('fetch-tag-preview', [tag]);
   if (!results) return null;
@@ -182,6 +187,7 @@ contextBridge.exposeInMainWorld('electron', {
   },
   loadMediaFromDB,
   loadMediaByDescriptionSearch,
+  loadMediaByQuery,
   fetchTagPreview,
   fetchTagCount,
   fetchMediaPreview,

--- a/src/main/query-sql.ts
+++ b/src/main/query-sql.ts
@@ -3,8 +3,12 @@ import type { Predicate } from '../renderer/query/types';
 
 export type FilteringMode = 'AND' | 'OR' | 'EXCLUSIVE';
 
-const BASE_COLUMNS =
-  'media.path, media.description, media.elo, media.height, media.width';
+// Columns returned for the library list. NOTE: `media.description` is
+// intentionally NOT selected — it's a large text column the list view doesn't
+// use (the detail/metadata view fetches it on demand). It is still available
+// as a WHERE filter (see clauseFor 'description'). Ordering is done in the
+// renderer, so queries emit no ORDER BY.
+const BASE_COLUMNS = 'media.path, media.elo, media.height, media.width';
 
 function clauseFor(p: Predicate, params: string[]): string {
   const like = `%${p.value}%`;
@@ -85,24 +89,40 @@ export function buildMediaQuery(
     const restWhere = facetedWhere(rest, joinOf, params);
     const extra = restWhere ? ` AND ${restWhere}` : '';
     const sql =
-      `SELECT mtcw.media_path AS path, media.description AS description, ` +
+      `SELECT mtcw.media_path AS path, ` +
       `media.elo AS elo, media.height AS height, media.width AS width, ` +
       `mtcw.weight AS weight, mtcw.tag_label AS tag_label, ` +
       `mtcw.time_stamp AS time_stamp, mtcw.created_at AS created_at ` +
       `FROM media_tag_by_category mtcw ` +
       `LEFT JOIN media ON media.path = mtcw.media_path ` +
-      `WHERE mtcw.tag_label = ?${extra} ` +
-      `ORDER BY mtcw.weight`;
+      `WHERE mtcw.tag_label = ?${extra}`;
     return { sql, params };
   }
 
-  // Fallback: no drivable include-tag (OR-only tags, exclude-only, or
-  // non-tag predicates). Scan media; LEFT JOIN the first include-tag, if any,
-  // only to surface weight/tag/timestamp columns.
+  // OR-set of include-tags: every predicate is an include-tag and none is a
+  // required AND driver (so they're an OR bucket) — "media with ANY of these
+  // tags" = tag_label IN (...). Drive from the indexed tag lookup instead of
+  // scanning all of `media` with an OR of EXISTS subqueries.
+  if (valid.every(isIncludeTag)) {
+    const params = valid.map((p) => p.value);
+    const placeholders = valid.map(() => '?').join(', ');
+    const sql =
+      `SELECT mtcw.media_path AS path, ` +
+      `media.elo AS elo, media.height AS height, media.width AS width, ` +
+      `mtcw.weight AS weight, mtcw.tag_label AS tag_label, ` +
+      `mtcw.time_stamp AS time_stamp, mtcw.created_at AS created_at ` +
+      `FROM media_tag_by_category mtcw ` +
+      `LEFT JOIN media ON media.path = mtcw.media_path ` +
+      `WHERE mtcw.tag_label IN (${placeholders})`;
+    return { sql, params };
+  }
+
+  // Fallback: no drivable include-tag (exclude-only, or non-tag predicates,
+  // or an OR bucket that mixes tags with non-tags). Scan media; LEFT JOIN the
+  // first include-tag, if any, only to surface weight/tag/timestamp columns.
   const primaryTag = valid.find(isIncludeTag)?.value;
   const params: string[] = [];
   let select: string;
-  let order = '';
   if (primaryTag) {
     select =
       `SELECT ${BASE_COLUMNS}, mtcw.weight AS weight, mtcw.tag_label AS tag_label, ` +
@@ -110,7 +130,6 @@ export function buildMediaQuery(
       `FROM media LEFT JOIN media_tag_by_category mtcw ` +
       `ON mtcw.media_path = media.path AND mtcw.tag_label = ?`;
     params.push(primaryTag); // JOIN param comes first in the SQL
-    order = ' ORDER BY mtcw.weight';
   } else {
     select =
       `SELECT ${BASE_COLUMNS}, NULL AS weight, NULL AS tag_label, ` +
@@ -118,5 +137,5 @@ export function buildMediaQuery(
   }
   const restWhere = facetedWhere(valid, joinOf, params);
   const where = restWhere ? ` WHERE ${restWhere}` : '';
-  return { sql: `${select}${where}${order}`, params };
+  return { sql: `${select}${where}`, params };
 }

--- a/src/main/query-sql.ts
+++ b/src/main/query-sql.ts
@@ -35,14 +35,71 @@ function clauseFor(p: Predicate, params: string[]): string {
   }
 }
 
+// Faceted WHERE over a predicate set: AND-bucket clauses are required, the
+// OR-bucket is grouped as "(a OR b ...)". Returns '' when there are none.
+function facetedWhere(
+  preds: Predicate[],
+  joinOf: (p: Predicate) => 'AND' | 'OR',
+  params: string[]
+): string {
+  const andClauses = preds.filter((p) => joinOf(p) !== 'OR').map((p) => clauseFor(p, params));
+  const orClauses = preds.filter((p) => joinOf(p) === 'OR').map((p) => clauseFor(p, params));
+  const pieces = [...andClauses];
+  if (orClauses.length > 0) {
+    pieces.push('(' + orClauses.join(' OR ') + ')');
+  }
+  return pieces.join(' AND ');
+}
+
 export function buildMediaQuery(
   predicates: Predicate[],
   mode: FilteringMode
 ): { sql: string; params: string[] } {
   const valid = (predicates || []).filter((p) => p && p.value);
-  // First INCLUDE tag drives the LEFT JOIN that surfaces weight/tag/timestamp.
-  const primaryTag = valid.find((p) => p.type === 'tag' && !p.exclude)?.value;
 
+  if (valid.length === 0) {
+    return {
+      sql:
+        `SELECT ${BASE_COLUMNS}, NULL AS weight, NULL AS tag_label, ` +
+        `NULL AS time_stamp, NULL AS created_at FROM media`,
+      params: [],
+    };
+  }
+
+  const defaultJoin: 'AND' | 'OR' = mode === 'OR' ? 'OR' : 'AND';
+  const joinOf = (p: Predicate): 'AND' | 'OR' => p.join ?? defaultJoin;
+  const isIncludeTag = (p: Predicate) => p.type === 'tag' && !p.exclude;
+
+  // Fast path: when a REQUIRED include-tag exists, DRIVE the query from the
+  // indexed media_tag_by_category lookup instead of scanning all of `media`.
+  // "Required" means the tag is a conjunct: it's in the AND bucket, or it's
+  // the only predicate (a lone OR-tag is still required). Driving an OR-tag
+  // that has OR siblings would wrongly force its presence, so we don't.
+  const driveTag =
+    valid.find((p) => isIncludeTag(p) && joinOf(p) !== 'OR') ??
+    (valid.length === 1 && isIncludeTag(valid[0]) ? valid[0] : undefined);
+
+  if (driveTag) {
+    const params: string[] = [driveTag.value]; // driving join param first
+    const rest = valid.filter((p) => p !== driveTag);
+    const restWhere = facetedWhere(rest, joinOf, params);
+    const extra = restWhere ? ` AND ${restWhere}` : '';
+    const sql =
+      `SELECT mtcw.media_path AS path, media.description AS description, ` +
+      `media.elo AS elo, media.height AS height, media.width AS width, ` +
+      `mtcw.weight AS weight, mtcw.tag_label AS tag_label, ` +
+      `mtcw.time_stamp AS time_stamp, mtcw.created_at AS created_at ` +
+      `FROM media_tag_by_category mtcw ` +
+      `LEFT JOIN media ON media.path = mtcw.media_path ` +
+      `WHERE mtcw.tag_label = ?${extra} ` +
+      `ORDER BY mtcw.weight`;
+    return { sql, params };
+  }
+
+  // Fallback: no drivable include-tag (OR-only tags, exclude-only, or
+  // non-tag predicates). Scan media; LEFT JOIN the first include-tag, if any,
+  // only to surface weight/tag/timestamp columns.
+  const primaryTag = valid.find(isIncludeTag)?.value;
   const params: string[] = [];
   let select: string;
   let order = '';
@@ -59,21 +116,7 @@ export function buildMediaQuery(
       `SELECT ${BASE_COLUMNS}, NULL AS weight, NULL AS tag_label, ` +
       `NULL AS time_stamp, NULL AS created_at FROM media`;
   }
-
-  if (valid.length === 0) {
-    return { sql: select, params };
-  }
-
-  const defaultJoin: 'AND' | 'OR' = mode === 'OR' ? 'OR' : 'AND';
-  const joinOf = (p: Predicate): 'AND' | 'OR' => p.join ?? defaultJoin;
-  const andPreds = valid.filter((p) => joinOf(p) !== 'OR');
-  const orPreds = valid.filter((p) => joinOf(p) === 'OR');
-  const andClauses = andPreds.map((p) => clauseFor(p, params));
-  const orClauses = orPreds.map((p) => clauseFor(p, params));
-  const pieces = [...andClauses];
-  if (orClauses.length > 0) {
-    pieces.push('(' + orClauses.join(' OR ') + ')');
-  }
-  const where = pieces.length ? ` WHERE ${pieces.join(' AND ')}` : '';
+  const restWhere = facetedWhere(valid, joinOf, params);
+  const where = restWhere ? ` WHERE ${restWhere}` : '';
   return { sql: `${select}${where}${order}`, params };
 }

--- a/src/main/query-sql.ts
+++ b/src/main/query-sql.ts
@@ -15,6 +15,13 @@ const BASE_COLUMNS = 'media.path, media.elo, media.height, media.width';
 const NULL_TAG_COLS =
   'NULL AS weight, NULL AS tag_label, NULL AS time_stamp, NULL AS created_at';
 
+// Columns when the query is DRIVEN from media_tag_by_category (mtcw), surfacing
+// the per-assignment weight/tag/timestamp.
+const DRIVEN_TAG_COLUMNS =
+  'mtcw.media_path AS path, media.elo AS elo, media.height AS height, ' +
+  'media.width AS width, mtcw.weight AS weight, mtcw.tag_label AS tag_label, ' +
+  'mtcw.time_stamp AS time_stamp, mtcw.created_at AS created_at';
+
 function clauseFor(p: Predicate, params: string[]): string {
   const like = `%${p.value}%`;
   switch (p.type) {
@@ -44,125 +51,21 @@ function clauseFor(p: Predicate, params: string[]): string {
   }
 }
 
-// Faceted WHERE over a predicate set: AND-bucket clauses are required, the
-// OR-bucket is grouped as "(a OR b ...)". Returns '' when there are none.
-function facetedWhere(
-  preds: Predicate[],
-  joinOf: (p: Predicate) => 'AND' | 'OR',
-  params: string[]
-): string {
-  const andClauses = preds.filter((p) => joinOf(p) !== 'OR').map((p) => clauseFor(p, params));
-  const orClauses = preds.filter((p) => joinOf(p) === 'OR').map((p) => clauseFor(p, params));
-  const pieces = [...andClauses];
-  if (orClauses.length > 0) {
-    pieces.push('(' + orClauses.join(' OR ') + ')');
-  }
-  return pieces.join(' AND ');
+// AND-join clauses for the conjunct "rest" of an intersection fast path.
+function andJoin(preds: Predicate[], params: string[]): string {
+  return preds.map((p) => clauseFor(p, params)).join(' AND ');
 }
 
-export function buildMediaQuery(
-  predicates: Predicate[],
-  mode: FilteringMode
+// General, always-correct path: scan `media` and combine the predicate clauses
+// LEFT-TO-RIGHT using the given connectors (connectors[i] joins valid[i+1] to
+// the running expression), parenthesized so evaluation is left-associative and
+// matches how the chips read. Surfaces tag columns via a LEFT JOIN on the first
+// include-tag (if any). Used for mixed AND/OR and exclude/non-tag-only queries.
+function mediaScan(
+  valid: Predicate[],
+  connectors: ('AND' | 'OR')[],
+  isIncludeTag: (p: Predicate) => boolean
 ): { sql: string; params: string[] } {
-  const valid = (predicates || []).filter((p) => p && p.value);
-
-  if (valid.length === 0) {
-    return {
-      sql:
-        `SELECT ${BASE_COLUMNS}, NULL AS weight, NULL AS tag_label, ` +
-        `NULL AS time_stamp, NULL AS created_at FROM media`,
-      params: [],
-    };
-  }
-
-  const defaultJoin: 'AND' | 'OR' = mode === 'OR' ? 'OR' : 'AND';
-  const joinOf = (p: Predicate): 'AND' | 'OR' => p.join ?? defaultJoin;
-  const isIncludeTag = (p: Predicate) => p.type === 'tag' && !p.exclude;
-  const isIncludeCat = (p: Predicate) => p.type === 'category' && !p.exclude;
-
-  // Fast path: when a REQUIRED include-tag exists, DRIVE the query from the
-  // indexed media_tag_by_category lookup instead of scanning all of `media`.
-  // "Required" means the tag is a conjunct: it's in the AND bucket, or it's
-  // the only predicate (a lone OR-tag is still required). Driving an OR-tag
-  // that has OR siblings would wrongly force its presence, so we don't.
-  const driveTag =
-    valid.find((p) => isIncludeTag(p) && joinOf(p) !== 'OR') ??
-    (valid.length === 1 && isIncludeTag(valid[0]) ? valid[0] : undefined);
-
-  if (driveTag) {
-    const params: string[] = [driveTag.value]; // driving join param first
-    const rest = valid.filter((p) => p !== driveTag);
-    const restWhere = facetedWhere(rest, joinOf, params);
-    const extra = restWhere ? ` AND ${restWhere}` : '';
-    const sql =
-      `SELECT mtcw.media_path AS path, ` +
-      `media.elo AS elo, media.height AS height, media.width AS width, ` +
-      `mtcw.weight AS weight, mtcw.tag_label AS tag_label, ` +
-      `mtcw.time_stamp AS time_stamp, mtcw.created_at AS created_at ` +
-      `FROM media_tag_by_category mtcw ` +
-      `LEFT JOIN media ON media.path = mtcw.media_path ` +
-      `WHERE mtcw.tag_label = ?${extra}`;
-    return { sql, params };
-  }
-
-  // Category fast path: when a REQUIRED include-category exists (and no
-  // drivable tag), DRIVE from the indexed category lookup instead of scanning
-  // `media`. A category spans many tags, so collapse to DISTINCT media_path
-  // (one row per media) and surface NULL tag columns.
-  const driveCat =
-    valid.find((p) => isIncludeCat(p) && joinOf(p) !== 'OR') ??
-    (valid.length === 1 && isIncludeCat(valid[0]) ? valid[0] : undefined);
-
-  if (driveCat) {
-    const params: string[] = [driveCat.value];
-    const rest = valid.filter((p) => p !== driveCat);
-    const restWhere = facetedWhere(rest, joinOf, params);
-    const where = restWhere ? ` WHERE ${restWhere}` : '';
-    const sql =
-      `SELECT media.path AS path, media.elo AS elo, media.height AS height, ` +
-      `media.width AS width, ${NULL_TAG_COLS} ` +
-      `FROM (SELECT DISTINCT media_path FROM media_tag_by_category ` +
-      `WHERE category_label = ?) cat ` +
-      `JOIN media ON media.path = cat.media_path${where}`;
-    return { sql, params };
-  }
-
-  // OR-set of include-tags: every predicate is an include-tag and none is a
-  // required AND driver (so they're an OR bucket) — "media with ANY of these
-  // tags" = tag_label IN (...). Drive from the indexed tag lookup instead of
-  // scanning all of `media` with an OR of EXISTS subqueries.
-  if (valid.every(isIncludeTag)) {
-    const params = valid.map((p) => p.value);
-    const placeholders = valid.map(() => '?').join(', ');
-    const sql =
-      `SELECT mtcw.media_path AS path, ` +
-      `media.elo AS elo, media.height AS height, media.width AS width, ` +
-      `mtcw.weight AS weight, mtcw.tag_label AS tag_label, ` +
-      `mtcw.time_stamp AS time_stamp, mtcw.created_at AS created_at ` +
-      `FROM media_tag_by_category mtcw ` +
-      `LEFT JOIN media ON media.path = mtcw.media_path ` +
-      `WHERE mtcw.tag_label IN (${placeholders})`;
-    return { sql, params };
-  }
-
-  // OR-set of include-categories: "media in ANY of these categories" =
-  // category_label IN (...), driven from the indexed category lookup
-  // (DISTINCT media, NULL tag columns).
-  if (valid.every(isIncludeCat)) {
-    const params = valid.map((p) => p.value);
-    const placeholders = valid.map(() => '?').join(', ');
-    const sql =
-      `SELECT media.path AS path, media.elo AS elo, media.height AS height, ` +
-      `media.width AS width, ${NULL_TAG_COLS} ` +
-      `FROM (SELECT DISTINCT media_path FROM media_tag_by_category ` +
-      `WHERE category_label IN (${placeholders})) cat ` +
-      `JOIN media ON media.path = cat.media_path`;
-    return { sql, params };
-  }
-
-  // Fallback: no drivable include-tag (exclude-only, or non-tag predicates,
-  // or an OR bucket that mixes tags with non-tags). Scan media; LEFT JOIN the
-  // first include-tag, if any, only to surface weight/tag/timestamp columns.
   const primaryTag = valid.find(isIncludeTag)?.value;
   const params: string[] = [];
   let select: string;
@@ -174,11 +77,104 @@ export function buildMediaQuery(
       `ON mtcw.media_path = media.path AND mtcw.tag_label = ?`;
     params.push(primaryTag); // JOIN param comes first in the SQL
   } else {
-    select =
-      `SELECT ${BASE_COLUMNS}, NULL AS weight, NULL AS tag_label, ` +
-      `NULL AS time_stamp, NULL AS created_at FROM media`;
+    select = `SELECT ${BASE_COLUMNS}, ${NULL_TAG_COLS} FROM media`;
   }
-  const restWhere = facetedWhere(valid, joinOf, params);
-  const where = restWhere ? ` WHERE ${restWhere}` : '';
-  return { sql: `${select}${where}`, params };
+  let expr = clauseFor(valid[0], params);
+  for (let i = 1; i < valid.length; i += 1) {
+    expr = `(${expr} ${connectors[i - 1]} ${clauseFor(valid[i], params)})`;
+  }
+  return { sql: `${select} WHERE ${expr}`, params };
+}
+
+export function buildMediaQuery(
+  predicates: Predicate[],
+  mode: FilteringMode
+): { sql: string; params: string[] } {
+  const valid = (predicates || []).filter((p) => p && p.value);
+
+  if (valid.length === 0) {
+    return {
+      sql: `SELECT ${BASE_COLUMNS}, ${NULL_TAG_COLS} FROM media`,
+      params: [],
+    };
+  }
+
+  const defaultJoin: 'AND' | 'OR' = mode === 'OR' ? 'OR' : 'AND';
+  const joinOf = (p: Predicate): 'AND' | 'OR' => p.join ?? defaultJoin;
+  const isIncludeTag = (p: Predicate) => p.type === 'tag' && !p.exclude;
+  const isIncludeCat = (p: Predicate) => p.type === 'category' && !p.exclude;
+
+  // Predicates combine LEFT-TO-RIGHT: the first predicate is the base and each
+  // subsequent predicate's join is the operator connecting it to the running
+  // result (its chip badge; the first chip's badge is hidden). So [a, b(OR)]
+  // reads "a OR b" (union) and [a, b(AND)] reads "a AND b" (intersection).
+  // Homogeneous all-AND / all-OR get index-driven fast paths; mixed operators
+  // fall back to a correct left-to-right media scan.
+  const connectors = valid.slice(1).map(joinOf);
+  const allOr = connectors.length > 0 && connectors.every((c) => c === 'OR');
+  const allAnd = connectors.every((c) => c === 'AND'); // also true for one predicate
+
+  // ---- Union (all-OR): "media with ANY of these" via an indexed IN lookup ----
+  if (allOr && valid.every(isIncludeTag)) {
+    const params = valid.map((p) => p.value);
+    const ph = valid.map(() => '?').join(', ');
+    return {
+      sql:
+        `SELECT ${DRIVEN_TAG_COLUMNS} FROM media_tag_by_category mtcw ` +
+        `LEFT JOIN media ON media.path = mtcw.media_path ` +
+        `WHERE mtcw.tag_label IN (${ph})`,
+      params,
+    };
+  }
+  if (allOr && valid.every(isIncludeCat)) {
+    const params = valid.map((p) => p.value);
+    const ph = valid.map(() => '?').join(', ');
+    return {
+      sql:
+        `SELECT ${BASE_COLUMNS}, ${NULL_TAG_COLS} ` +
+        `FROM (SELECT DISTINCT media_path FROM media_tag_by_category ` +
+        `WHERE category_label IN (${ph})) cat ` +
+        `JOIN media ON media.path = cat.media_path`,
+      params,
+    };
+  }
+
+  // ---- Intersection (single predicate or all-AND): drive from an indexed
+  //      tag/category, with the rest as AND conjuncts ----
+  if (allAnd) {
+    const driveTag = valid.find(isIncludeTag);
+    if (driveTag) {
+      const params: string[] = [driveTag.value]; // driving join param first
+      const rest = valid.filter((p) => p !== driveTag);
+      const restWhere = andJoin(rest, params);
+      const extra = restWhere ? ` AND ${restWhere}` : '';
+      return {
+        sql:
+          `SELECT ${DRIVEN_TAG_COLUMNS} FROM media_tag_by_category mtcw ` +
+          `LEFT JOIN media ON media.path = mtcw.media_path ` +
+          `WHERE mtcw.tag_label = ?${extra}`,
+        params,
+      };
+    }
+    const driveCat = valid.find(isIncludeCat);
+    if (driveCat) {
+      const params: string[] = [driveCat.value];
+      const rest = valid.filter((p) => p !== driveCat);
+      const restWhere = andJoin(rest, params);
+      const where = restWhere ? ` WHERE ${restWhere}` : '';
+      return {
+        sql:
+          `SELECT ${BASE_COLUMNS}, ${NULL_TAG_COLS} ` +
+          `FROM (SELECT DISTINCT media_path FROM media_tag_by_category ` +
+          `WHERE category_label = ?) cat ` +
+          `JOIN media ON media.path = cat.media_path${where}`,
+        params,
+      };
+    }
+    // No drivable tag/category (paths/hash/excludes only) → AND media scan.
+    return mediaScan(valid, connectors, isIncludeTag);
+  }
+
+  // ---- Mixed AND/OR operators → correct left-to-right media scan ----
+  return mediaScan(valid, connectors, isIncludeTag);
 }

--- a/src/main/query-sql.ts
+++ b/src/main/query-sql.ts
@@ -3,8 +3,8 @@ import type { Predicate } from '../renderer/query/types';
 
 export type FilteringMode = 'AND' | 'OR' | 'EXCLUSIVE';
 
-const BASE_SELECT =
-  'SELECT media.path, media.description, media.elo, media.height, media.width FROM media';
+const BASE_COLUMNS =
+  'media.path, media.description, media.elo, media.height, media.width';
 
 function clauseFor(p: Predicate, params: string[]): string {
   const like = `%${p.value}%`;
@@ -39,21 +39,41 @@ export function buildMediaQuery(
   predicates: Predicate[],
   mode: FilteringMode
 ): { sql: string; params: string[] } {
-  const params: string[] = [];
   const valid = (predicates || []).filter((p) => p && p.value);
-  if (valid.length === 0) {
-    return { sql: BASE_SELECT, params };
+  // First INCLUDE tag drives the LEFT JOIN that surfaces weight/tag/timestamp.
+  const primaryTag = valid.find((p) => p.type === 'tag' && !p.exclude)?.value;
+
+  const params: string[] = [];
+  let select: string;
+  let order = '';
+  if (primaryTag) {
+    select =
+      `SELECT ${BASE_COLUMNS}, mtcw.weight AS weight, mtcw.tag_label AS tag_label, ` +
+      `mtcw.time_stamp AS time_stamp, mtcw.created_at AS created_at ` +
+      `FROM media LEFT JOIN media_tag_by_category mtcw ` +
+      `ON mtcw.media_path = media.path AND mtcw.tag_label = ?`;
+    params.push(primaryTag); // JOIN param comes first in the SQL
+    order = ' ORDER BY mtcw.weight';
+  } else {
+    select =
+      `SELECT ${BASE_COLUMNS}, NULL AS weight, NULL AS tag_label, ` +
+      `NULL AS time_stamp, NULL AS created_at FROM media`;
   }
+
+  if (valid.length === 0) {
+    return { sql: select, params };
+  }
+
   const defaultJoin: 'AND' | 'OR' = mode === 'OR' ? 'OR' : 'AND';
   const joinOf = (p: Predicate): 'AND' | 'OR' => p.join ?? defaultJoin;
   const andPreds = valid.filter((p) => joinOf(p) !== 'OR');
   const orPreds = valid.filter((p) => joinOf(p) === 'OR');
-  // Build in emission order so params line up with placeholders.
   const andClauses = andPreds.map((p) => clauseFor(p, params));
   const orClauses = orPreds.map((p) => clauseFor(p, params));
   const pieces = [...andClauses];
   if (orClauses.length > 0) {
     pieces.push('(' + orClauses.join(' OR ') + ')');
   }
-  return { sql: `${BASE_SELECT} WHERE ${pieces.join(' AND ')}`, params };
+  const where = pieces.length ? ` WHERE ${pieces.join(' AND ')}` : '';
+  return { sql: `${select}${where}${order}`, params };
 }

--- a/src/main/query-sql.ts
+++ b/src/main/query-sql.ts
@@ -44,8 +44,16 @@ export function buildMediaQuery(
   if (valid.length === 0) {
     return { sql: BASE_SELECT, params };
   }
-  const joiner = mode === 'OR' ? ' OR ' : ' AND ';
-  const clauses = valid.map((p) => clauseFor(p, params));
-  const where = clauses.join(joiner);
-  return { sql: `${BASE_SELECT} WHERE ${where}`, params };
+  const defaultJoin: 'AND' | 'OR' = mode === 'OR' ? 'OR' : 'AND';
+  const joinOf = (p: Predicate): 'AND' | 'OR' => p.join ?? defaultJoin;
+  const andPreds = valid.filter((p) => joinOf(p) !== 'OR');
+  const orPreds = valid.filter((p) => joinOf(p) === 'OR');
+  // Build in emission order so params line up with placeholders.
+  const andClauses = andPreds.map((p) => clauseFor(p, params));
+  const orClauses = orPreds.map((p) => clauseFor(p, params));
+  const pieces = [...andClauses];
+  if (orClauses.length > 0) {
+    pieces.push('(' + orClauses.join(' OR ') + ')');
+  }
+  return { sql: `${BASE_SELECT} WHERE ${pieces.join(' AND ')}`, params };
 }

--- a/src/main/query-sql.ts
+++ b/src/main/query-sql.ts
@@ -1,0 +1,51 @@
+// src/main/query-sql.ts
+import type { Predicate } from '../renderer/query/types';
+
+export type FilteringMode = 'AND' | 'OR' | 'EXCLUSIVE';
+
+const BASE_SELECT =
+  'SELECT media.path, media.description, media.elo, media.height, media.width FROM media';
+
+function clauseFor(p: Predicate, params: string[]): string {
+  const like = `%${p.value}%`;
+  switch (p.type) {
+    case 'tag':
+      params.push(p.value);
+      return p.exclude
+        ? '(NOT EXISTS (SELECT 1 FROM media_tag_by_category mtc WHERE mtc.media_path = media.path AND mtc.tag_label = ?))'
+        : '(EXISTS (SELECT 1 FROM media_tag_by_category mtc WHERE mtc.media_path = media.path AND mtc.tag_label = ?))';
+    case 'category':
+      params.push(p.value);
+      return p.exclude
+        ? '(NOT EXISTS (SELECT 1 FROM media_tag_by_category mtc WHERE mtc.media_path = media.path AND mtc.category_label = ?))'
+        : '(EXISTS (SELECT 1 FROM media_tag_by_category mtc WHERE mtc.media_path = media.path AND mtc.category_label = ?))';
+    case 'path':
+      params.push(like);
+      return p.exclude ? '(media.path NOT LIKE ?)' : '(media.path LIKE ?)';
+    case 'description':
+      params.push(like);
+      return p.exclude ? '(media.description NOT LIKE ?)' : '(media.description LIKE ?)';
+    case 'hash':
+      params.push(like);
+      return p.exclude ? '(media.hash NOT LIKE ?)' : '(media.hash LIKE ?)';
+    default: {
+      const _never: never = p.type as never;
+      throw new Error(`Unknown predicate type: ${_never}`);
+    }
+  }
+}
+
+export function buildMediaQuery(
+  predicates: Predicate[],
+  mode: FilteringMode
+): { sql: string; params: string[] } {
+  const params: string[] = [];
+  const valid = (predicates || []).filter((p) => p && p.value);
+  if (valid.length === 0) {
+    return { sql: BASE_SELECT, params };
+  }
+  const joiner = mode === 'OR' ? ' OR ' : ' AND ';
+  const clauses = valid.map((p) => clauseFor(p, params));
+  const where = clauses.join(joiner);
+  return { sql: `${BASE_SELECT} WHERE ${where}`, params };
+}

--- a/src/main/query-sql.ts
+++ b/src/main/query-sql.ts
@@ -10,6 +10,11 @@ export type FilteringMode = 'AND' | 'OR' | 'EXCLUSIVE';
 // renderer, so queries emit no ORDER BY.
 const BASE_COLUMNS = 'media.path, media.elo, media.height, media.width';
 
+// Tag columns are NULL for category-driven / no-tag queries (a category spans
+// many tags, so there's no single per-tag weight/timestamp to surface).
+const NULL_TAG_COLS =
+  'NULL AS weight, NULL AS tag_label, NULL AS time_stamp, NULL AS created_at';
+
 function clauseFor(p: Predicate, params: string[]): string {
   const like = `%${p.value}%`;
   switch (p.type) {
@@ -73,6 +78,7 @@ export function buildMediaQuery(
   const defaultJoin: 'AND' | 'OR' = mode === 'OR' ? 'OR' : 'AND';
   const joinOf = (p: Predicate): 'AND' | 'OR' => p.join ?? defaultJoin;
   const isIncludeTag = (p: Predicate) => p.type === 'tag' && !p.exclude;
+  const isIncludeCat = (p: Predicate) => p.type === 'category' && !p.exclude;
 
   // Fast path: when a REQUIRED include-tag exists, DRIVE the query from the
   // indexed media_tag_by_category lookup instead of scanning all of `media`.
@@ -99,6 +105,28 @@ export function buildMediaQuery(
     return { sql, params };
   }
 
+  // Category fast path: when a REQUIRED include-category exists (and no
+  // drivable tag), DRIVE from the indexed category lookup instead of scanning
+  // `media`. A category spans many tags, so collapse to DISTINCT media_path
+  // (one row per media) and surface NULL tag columns.
+  const driveCat =
+    valid.find((p) => isIncludeCat(p) && joinOf(p) !== 'OR') ??
+    (valid.length === 1 && isIncludeCat(valid[0]) ? valid[0] : undefined);
+
+  if (driveCat) {
+    const params: string[] = [driveCat.value];
+    const rest = valid.filter((p) => p !== driveCat);
+    const restWhere = facetedWhere(rest, joinOf, params);
+    const where = restWhere ? ` WHERE ${restWhere}` : '';
+    const sql =
+      `SELECT media.path AS path, media.elo AS elo, media.height AS height, ` +
+      `media.width AS width, ${NULL_TAG_COLS} ` +
+      `FROM (SELECT DISTINCT media_path FROM media_tag_by_category ` +
+      `WHERE category_label = ?) cat ` +
+      `JOIN media ON media.path = cat.media_path${where}`;
+    return { sql, params };
+  }
+
   // OR-set of include-tags: every predicate is an include-tag and none is a
   // required AND driver (so they're an OR bucket) — "media with ANY of these
   // tags" = tag_label IN (...). Drive from the indexed tag lookup instead of
@@ -114,6 +142,21 @@ export function buildMediaQuery(
       `FROM media_tag_by_category mtcw ` +
       `LEFT JOIN media ON media.path = mtcw.media_path ` +
       `WHERE mtcw.tag_label IN (${placeholders})`;
+    return { sql, params };
+  }
+
+  // OR-set of include-categories: "media in ANY of these categories" =
+  // category_label IN (...), driven from the indexed category lookup
+  // (DISTINCT media, NULL tag columns).
+  if (valid.every(isIncludeCat)) {
+    const params = valid.map((p) => p.value);
+    const placeholders = valid.map(() => '?').join(', ');
+    const sql =
+      `SELECT media.path AS path, media.elo AS elo, media.height AS height, ` +
+      `media.width AS width, ${NULL_TAG_COLS} ` +
+      `FROM (SELECT DISTINCT media_path FROM media_tag_by_category ` +
+      `WHERE category_label IN (${placeholders})) cat ` +
+      `JOIN media ON media.path = cat.media_path`;
     return { sql, params };
   }
 

--- a/src/main/sessionStore.ts
+++ b/src/main/sessionStore.ts
@@ -50,7 +50,7 @@ export interface SessionQueryData {
 export interface SessionPreviousData {
   previousLibrary: SessionLibraryData['library'];
   previousCursor: number;
-  previousStateType?: 'fs' | 'db' | 'search' | null;
+  previousStateType?: 'fs' | 'db' | null;
   previousTextFilter?: string;
   previousDbQuery?: { tags: string[] };
   previousInitialFile?: string;

--- a/src/main/taxonomy.ts
+++ b/src/main/taxonomy.ts
@@ -93,6 +93,26 @@ const getTagCount =
     return results.count;
   };
 
+const loadPathSuggestions =
+  (db: Database) => async (_: IpcMainInvokeEvent, args: [string]) => {
+    const term = `%${args[0] || ''}%`;
+    const rows = await db.all(
+      `SELECT DISTINCT path FROM media WHERE path LIKE $1 LIMIT 50`,
+      [term]
+    );
+    return rows.map((r: any) => r.path);
+  };
+
+const getCategoryCount =
+  (db: Database) => async (_: IpcMainInvokeEvent, args: [string]) => {
+    const category = args[0];
+    const result = await db.get(
+      `SELECT COUNT(DISTINCT media_path) AS count FROM media_tag_by_category WHERE category_label = $1`,
+      [category]
+    );
+    return result?.count ?? 0;
+  };
+
 type TagInput = [string, string];
 
 const createTag =
@@ -732,6 +752,8 @@ export {
   loadCategoryTags,
   loadAllTags,
   getTagCount,
+  loadPathSuggestions,
+  getCategoryCount,
   createTag,
   createAssignment,
   createCategory,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -47,7 +47,6 @@ export default function App(): JSX.Element {
       state.matches({ library: 'boot' }) ||
       state.matches({ library: 'selectingDB' }) ||
       state.matches({ library: 'loadingFromFS' }) ||
-      state.matches({ library: 'loadingFromSearch' }) ||
       state.matches({ library: 'loadingDB' })
     );
   }, [state]);

--- a/src/renderer/components/controls/command-palette-search.tsx
+++ b/src/renderer/components/controls/command-palette-search.tsx
@@ -1,0 +1,137 @@
+// CommandPaletteSearch — the unified query surface for the command palette.
+//
+// Replaces the old ListContextDisplay tag/search pill row. Renders the chip
+// QueryInput plus an in-place type-ahead results surface (Tags + Categories /
+// Paths / Description / Hash). Selecting a result adds a predicate to the SAME
+// query state the taxonomy sidebar drives, so the palette and sidebar stay in
+// lockstep. Kept compact + scrollable to fit the floating palette.
+import { useState } from 'react';
+import { useSelector } from '@xstate/react';
+import { useQuery } from '@tanstack/react-query';
+import type { Predicate } from '../../query/types';
+import { invoke } from '../../platform';
+import { useTagSearch } from '../../hooks/useTagSearch';
+import QueryInput from '../query-input/QueryInput';
+import SuggestionSections from '../taxonomy/suggestion-sections';
+
+// Compact cap for the palette's Tags section — the sidebar shows far more, but
+// the floating palette is tight on space.
+const PALETTE_TAG_CAP = 12;
+
+interface CategoryLite {
+  label: string;
+  weight?: number;
+  description?: string;
+}
+
+async function loadCategories(): Promise<CategoryLite[]> {
+  const result = await invoke('load-categories', []);
+  return (result as CategoryLite[]) ?? [];
+}
+
+interface CommandPaletteSearchProps {
+  // InterpreterFrom<typeof libraryMachine>; typed loosely to match the rest of
+  // command-palette.tsx which threads libraryService as `any`.
+  libraryService: any;
+}
+
+export default function CommandPaletteSearch({
+  libraryService,
+}: CommandPaletteSearchProps) {
+  const query = useSelector(libraryService, (s: any) => s.context.query);
+  const filteringMode = useSelector(
+    libraryService,
+    (s: any) => s.context.settings.filteringMode
+  );
+  const initSessionId = useSelector(
+    libraryService,
+    (s: any) => s.context.initSessionId
+  );
+
+  const [text, setText] = useState('');
+
+  const { results: tagResults } = useTagSearch(text, text.length > 0);
+
+  const { data: categories } = useQuery<CategoryLite[], Error>(
+    ['taxonomy', 'categories', initSessionId],
+    loadCategories,
+    { staleTime: Infinity }
+  );
+
+  const join: 'AND' | 'OR' = filteringMode === 'OR' ? 'OR' : 'AND';
+
+  const clearText = () => setText('');
+
+  const addPredicate = (predicate: Predicate) => {
+    libraryService.send({
+      type: 'ADD_PREDICATE',
+      data: { predicate: { ...predicate, join } },
+    });
+  };
+
+  const addTag = (label: string) => {
+    addPredicate({ type: 'tag', value: label, exclude: false });
+    clearText();
+  };
+
+  const hasText = text.length > 0;
+
+  return (
+    <div className="commandPaletteSearch">
+      <QueryInput
+        query={query}
+        textValue={text}
+        onTextChange={setText}
+        onSubmitText={() => {
+          // Commit the top tag suggestion as a predicate, then clear text.
+          const top = tagResults[0];
+          if (top) {
+            addTag(top.label);
+          }
+        }}
+        onRemovePredicate={(key) =>
+          libraryService.send({ type: 'REMOVE_PREDICATE', data: { key } })
+        }
+        onToggleExclude={(key) =>
+          libraryService.send({ type: 'TOGGLE_EXCLUDE', data: { key } })
+        }
+        onSetPredicateJoin={(key, j) =>
+          libraryService.send({
+            type: 'SET_PREDICATE_JOIN',
+            data: { key, join: j },
+          })
+        }
+        onClearAll={() => {
+          libraryService.send({ type: 'CLEAR_QUERY' });
+          clearText();
+        }}
+      />
+
+      {hasText && (
+        <div className="commandPaletteSearchResults">
+          {tagResults.length > 0 && (
+            <div className="suggestion-section">
+              <div className="suggestion-section-label">Tags</div>
+              {tagResults.slice(0, PALETTE_TAG_CAP).map((t) => (
+                <div
+                  key={t.label}
+                  className="suggestion-row"
+                  onClick={() => addTag(t.label)}
+                >
+                  <span className="suggestion-prefix">#</span>
+                  <span className="suggestion-value">{t.label}</span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <SuggestionSections
+            text={text}
+            categories={categories ?? []}
+            onAdd={(predicate) => addPredicate(predicate)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/controls/command-palette-search.tsx
+++ b/src/renderer/components/controls/command-palette-search.tsx
@@ -163,6 +163,7 @@ export default function CommandPaletteSearch({
             data: { key, join: j },
           })
         }
+        onClearText={clearText}
         onClearAll={() => {
           libraryService.send({ type: 'CLEAR_QUERY' });
           clearText();

--- a/src/renderer/components/controls/command-palette-search.tsx
+++ b/src/renderer/components/controls/command-palette-search.tsx
@@ -7,12 +7,14 @@
 // lockstep. Kept compact + scrollable to fit the floating palette.
 import { useMemo, useState } from 'react';
 import { useSelector } from '@xstate/react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { Predicate } from '../../query/types';
 import { invoke } from '../../platform';
 import { useTagSearch } from '../../hooks/useTagSearch';
+import type { TagConcept } from '../../hooks/useTagSearch';
 import QueryInput from '../query-input/QueryInput';
 import SuggestionSections from '../taxonomy/suggestion-sections';
+import TagPlusIcon from '../icons/tag-plus-icon';
 
 // Compact cap for the palette's Tags section — the sidebar shows far more, but
 // the floating palette is tight on space.
@@ -33,20 +35,66 @@ interface CommandPaletteSearchProps {
   // InterpreterFrom<typeof libraryMachine>; typed loosely to match the rest of
   // command-palette.tsx which threads libraryService as `any`.
   libraryService: any;
+  // The media item under the cursor; the apply-tag button assigns to its path.
+  currentItem?: { path?: string } | null;
 }
 
 export default function CommandPaletteSearch({
   libraryService,
+  currentItem,
 }: CommandPaletteSearchProps) {
+  const queryClient = useQueryClient();
   const query = useSelector(libraryService, (s: any) => s.context.query);
   const filteringMode = useSelector(
     libraryService,
     (s: any) => s.context.settings.filteringMode
   );
+  const applyTagPreview = useSelector(
+    libraryService,
+    (s: any) => s.context.settings.applyTagPreview
+  );
   const initSessionId = useSelector(
     libraryService,
     (s: any) => s.context.initSessionId
   );
+
+  const currentPath = currentItem?.path;
+
+  // Apply a tag to the current media item (an assignment) — distinct from
+  // clicking the row, which adds the tag to the search query.
+  const applyTagToCurrent = async (t: TagConcept) => {
+    if (!currentPath) return;
+    try {
+      await invoke('create-assignment', [
+        [currentPath],
+        t.label,
+        t.category,
+        null,
+        applyTagPreview,
+      ]);
+      queryClient.invalidateQueries({ queryKey: ['metadata'] });
+      queryClient.invalidateQueries({ queryKey: ['taxonomy', 'tag', t.label] });
+      queryClient.invalidateQueries({ queryKey: ['tags-by-path'] });
+      libraryService.send({
+        type: 'ADD_TOAST',
+        data: {
+          type: 'success',
+          title: `Applied "${t.label}"`,
+          message: currentPath.split(/[\\/]/).pop(),
+          durationMs: 2000,
+        },
+      });
+    } catch (err) {
+      libraryService.send({
+        type: 'ADD_TOAST',
+        data: {
+          type: 'error',
+          title: 'Tag failed',
+          message: err instanceof Error ? err.message : 'Could not apply tag',
+        },
+      });
+    }
+  };
 
   const [text, setText] = useState('');
 
@@ -137,6 +185,19 @@ export default function CommandPaletteSearch({
                   <span className="suggestion-value">{t.label}</span>
                   {t.category && t.category !== 'Suggested' && (
                     <span className="suggestion-meta">{t.category}</span>
+                  )}
+                  {currentPath && (
+                    <button
+                      type="button"
+                      className="suggestion-apply"
+                      title={`Apply "${t.label}" to the current item`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        applyTagToCurrent(t);
+                      }}
+                    >
+                      <TagPlusIcon />
+                    </button>
                   )}
                 </div>
               ))}

--- a/src/renderer/components/controls/command-palette-search.tsx
+++ b/src/renderer/components/controls/command-palette-search.tsx
@@ -5,7 +5,7 @@
 // Paths / Description / Hash). Selecting a result adds a predicate to the SAME
 // query state the taxonomy sidebar drives, so the palette and sidebar stay in
 // lockstep. Kept compact + scrollable to fit the floating palette.
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useSelector } from '@xstate/react';
 import { useQuery } from '@tanstack/react-query';
 import type { Predicate } from '../../query/types';
@@ -52,6 +52,19 @@ export default function CommandPaletteSearch({
 
   const { results: tagResults } = useTagSearch(text, text.length > 0);
 
+  // Prioritize curated tags (any category other than the catch-all "Suggested"
+  // autotag bucket) — they're far more useful, so surface them first. Stable
+  // sort preserves fuzzy-match relevance order within each group.
+  const sortedTags = useMemo(
+    () =>
+      [...tagResults].sort(
+        (a, b) =>
+          (a.category === 'Suggested' ? 1 : 0) -
+          (b.category === 'Suggested' ? 1 : 0)
+      ),
+    [tagResults]
+  );
+
   const { data: categories } = useQuery<CategoryLite[], Error>(
     ['taxonomy', 'categories', initSessionId],
     loadCategories,
@@ -85,7 +98,7 @@ export default function CommandPaletteSearch({
         onTextChange={setText}
         onSubmitText={() => {
           // Commit the top tag suggestion as a predicate, then clear text.
-          const top = tagResults[0];
+          const top = sortedTags[0];
           if (top) {
             addTag(top.label);
           }
@@ -110,17 +123,21 @@ export default function CommandPaletteSearch({
 
       {hasText && (
         <div className="commandPaletteSearchResults">
-          {tagResults.length > 0 && (
+          {sortedTags.length > 0 && (
             <div className="suggestion-section">
               <div className="suggestion-section-label">Tags</div>
-              {tagResults.slice(0, PALETTE_TAG_CAP).map((t) => (
+              {sortedTags.slice(0, PALETTE_TAG_CAP).map((t) => (
                 <div
                   key={t.label}
                   className="suggestion-row"
+                  title={t.label}
                   onClick={() => addTag(t.label)}
                 >
                   <span className="suggestion-prefix">#</span>
                   <span className="suggestion-value">{t.label}</span>
+                  {t.category && t.category !== 'Suggested' && (
+                    <span className="suggestion-meta">{t.category}</span>
+                  )}
                 </div>
               ))}
             </div>

--- a/src/renderer/components/controls/command-palette-search.tsx
+++ b/src/renderer/components/controls/command-palette-search.tsx
@@ -79,6 +79,7 @@ export default function CommandPaletteSearch({
   return (
     <div className="commandPaletteSearch">
       <QueryInput
+        autoFocus
         query={query}
         textValue={text}
         onTextChange={setText}

--- a/src/renderer/components/controls/command-palette-search.tsx
+++ b/src/renderer/components/controls/command-palette-search.tsx
@@ -5,15 +5,17 @@
 // Paths / Description / Hash). Selecting a result adds a predicate to the SAME
 // query state the taxonomy sidebar drives, so the palette and sidebar stay in
 // lockstep. Kept compact + scrollable to fit the floating palette.
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from '@xstate/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { Predicate } from '../../query/types';
 import { invoke } from '../../platform';
 import { useTagSearch } from '../../hooks/useTagSearch';
 import type { TagConcept } from '../../hooks/useTagSearch';
+import { useSearchHistory } from '../../hooks/useSearchHistory';
 import QueryInput from '../query-input/QueryInput';
 import SuggestionSections from '../taxonomy/suggestion-sections';
+import type { SuggestionItem } from '../taxonomy/suggestion-sections';
 import TagPlusIcon from '../icons/tag-plus-icon';
 
 // Compact cap for the palette's Tags section — the sidebar shows far more, but
@@ -96,7 +98,15 @@ export default function CommandPaletteSearch({
     }
   };
 
+  const { addSearch } = useSearchHistory();
+
   const [text, setText] = useState('');
+  // Index into `navItems` of the currently highlighted result. Enter commits
+  // it; arrow keys move it; the top result is highlighted by default.
+  const [highlightIndex, setHighlightIndex] = useState(0);
+  // Ordered suggestion rows reported up by SuggestionSections, so the highlight
+  // can span tags *and* suggestions as one list.
+  const [suggestionItems, setSuggestionItems] = useState<SuggestionItem[]>([]);
 
   const { results: tagResults } = useTagSearch(text, text.length > 0);
 
@@ -121,21 +131,65 @@ export default function CommandPaletteSearch({
 
   const join: 'AND' | 'OR' = filteringMode === 'OR' ? 'OR' : 'AND';
 
+  const hasText = text.length > 0;
+
   const clearText = () => setText('');
 
-  const addPredicate = (predicate: Predicate) => {
+  // The tag rows shown in the palette (capped). They lead the navigable list.
+  const cappedTags = useMemo(
+    () => sortedTags.slice(0, PALETTE_TAG_CAP),
+    [sortedTags]
+  );
+
+  // The full, ordered set the keyboard moves through: tags first (in render
+  // order), then the suggestion rows. Empty unless the user is searching.
+  const navItems: SuggestionItem[] = useMemo(() => {
+    if (!hasText) return [];
+    const tagItems: SuggestionItem[] = cappedTags.map((t) => ({
+      key: `tag:${t.label}`,
+      predicate: { type: 'tag', value: t.label, exclude: false },
+    }));
+    return [...tagItems, ...suggestionItems];
+  }, [hasText, cappedTags, suggestionItems]);
+
+  // Clamp the stored index to the live list — the result count changes as the
+  // user types and as async suggestions arrive.
+  const safeIndex =
+    navItems.length === 0
+      ? -1
+      : Math.min(Math.max(highlightIndex, 0), navItems.length - 1);
+  const highlightedKey = safeIndex >= 0 ? navItems[safeIndex].key : null;
+
+  // Snap the highlight back to the top result whenever the query text changes.
+  useEffect(() => {
+    setHighlightIndex(0);
+  }, [text]);
+
+  // Commit a chosen result: add it to the query AND record it in recent
+  // searches (the user selected it — that's the search worth remembering),
+  // then clear the typed text.
+  const commitPredicate = (predicate: Predicate) => {
     libraryService.send({
       type: 'ADD_PREDICATE',
       data: { predicate: { ...predicate, join } },
     });
-  };
-
-  const addTag = (label: string) => {
-    addPredicate({ type: 'tag', value: label, exclude: false });
+    addSearch(predicate.value);
     clearText();
+    setHighlightIndex(0);
   };
 
-  const hasText = text.length > 0;
+  const moveHighlight = (delta: 1 | -1) => {
+    if (navItems.length === 0) return;
+    setHighlightIndex((prev) => {
+      const base = prev < 0 ? 0 : prev;
+      return (base + delta + navItems.length) % navItems.length;
+    });
+  };
+
+  const highlightByKey = (key: string) => {
+    const idx = navItems.findIndex((n) => n.key === key);
+    if (idx >= 0) setHighlightIndex(idx);
+  };
 
   return (
     <div className="commandPaletteSearch">
@@ -145,10 +199,11 @@ export default function CommandPaletteSearch({
         textValue={text}
         onTextChange={setText}
         onSubmitText={() => {
-          // Commit the top tag suggestion as a predicate, then clear text.
+          // Fallback for the brief window before suggestions populate (when
+          // resultNavCount is still 0): commit the top tag if there is one.
           const top = sortedTags[0];
           if (top) {
-            addTag(top.label);
+            commitPredicate({ type: 'tag', value: top.label, exclude: false });
           }
         }}
         onRemovePredicate={(key) =>
@@ -168,19 +223,33 @@ export default function CommandPaletteSearch({
           libraryService.send({ type: 'CLEAR_QUERY' });
           clearText();
         }}
+        resultNavCount={navItems.length}
+        onResultNavMove={moveHighlight}
+        onResultNavSubmit={() => {
+          if (safeIndex >= 0) commitPredicate(navItems[safeIndex].predicate);
+        }}
       />
 
       {hasText && (
         <div className="commandPaletteSearchResults">
-          {sortedTags.length > 0 && (
+          {cappedTags.length > 0 && (
             <div className="suggestion-section">
               <div className="suggestion-section-label">Tags</div>
-              {sortedTags.slice(0, PALETTE_TAG_CAP).map((t) => (
+              {cappedTags.map((t, i) => (
                 <div
                   key={t.label}
-                  className="suggestion-row"
+                  className={`suggestion-row${
+                    safeIndex === i ? ' highlighted' : ''
+                  }`}
                   title={t.label}
-                  onClick={() => addTag(t.label)}
+                  onMouseEnter={() => setHighlightIndex(i)}
+                  onClick={() =>
+                    commitPredicate({
+                      type: 'tag',
+                      value: t.label,
+                      exclude: false,
+                    })
+                  }
                 >
                   <span className="suggestion-prefix">#</span>
                   <span className="suggestion-value">{t.label}</span>
@@ -208,7 +277,10 @@ export default function CommandPaletteSearch({
           <SuggestionSections
             text={text}
             categories={categories ?? []}
-            onAdd={(predicate) => addPredicate(predicate)}
+            onAdd={(predicate) => commitPredicate(predicate)}
+            onItemsChange={setSuggestionItems}
+            highlightedKey={highlightedKey}
+            onHighlightKey={highlightByKey}
           />
         </div>
       )}

--- a/src/renderer/components/controls/command-palette-search.tsx
+++ b/src/renderer/components/controls/command-palette-search.tsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from '@xstate/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { Predicate } from '../../query/types';
+import { getNextFilterMode } from '../../../settings';
 import { invoke } from '../../platform';
 import { useTagSearch } from '../../hooks/useTagSearch';
 import type { TagConcept } from '../../hooks/useTagSearch';
@@ -198,6 +199,13 @@ export default function CommandPaletteSearch({
         query={query}
         textValue={text}
         onTextChange={setText}
+        filteringMode={filteringMode}
+        onCycleFilterMode={() =>
+          libraryService.send({
+            type: 'CHANGE_SETTING',
+            data: { filteringMode: getNextFilterMode(filteringMode) },
+          })
+        }
         onSubmitText={() => {
           // Fallback for the brief window before suggestions populate (when
           // resultNavCount is still 0): commit the top tag if there is one.

--- a/src/renderer/components/controls/command-palette.css
+++ b/src/renderer/components/controls/command-palette.css
@@ -662,6 +662,15 @@
   background: rgba(255, 255, 255, 0.08);
 }
 
+/* Keyboard-navigation highlight — matches the palette selector specificity so
+   it wins over the base row color, with an accent bar marking the active row
+   that Enter will commit. */
+.CommandPalette .commandPaletteSearchResults .suggestion-row.highlighted {
+  background: rgba(95, 169, 120, 0.18);
+  color: #fff;
+  box-shadow: inset 2px 0 0 0 #5fa978;
+}
+
 .CommandPalette .commandPaletteSearchResults .suggestion-prefix {
   color: rgba(255, 255, 255, 0.4);
   font-size: 11px;

--- a/src/renderer/components/controls/command-palette.css
+++ b/src/renderer/components/controls/command-palette.css
@@ -685,3 +685,36 @@
   font-size: 10px;
   color: rgba(255, 255, 255, 0.35);
 }
+
+/* Apply-tag-to-current-item button on a tag result row. Sits at the right
+   edge; pushed there by the flex-growing value (or after the category meta). */
+.CommandPalette .commandPaletteSearchResults .suggestion-apply {
+  flex: 0 0 auto;
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.45);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+/* When a category meta is present it already takes margin-left:auto, so the
+   apply button should sit snug after it rather than push again. */
+.CommandPalette
+  .commandPaletteSearchResults
+  .suggestion-meta
+  + .suggestion-apply {
+  margin-left: 4px;
+}
+
+.CommandPalette .commandPaletteSearchResults .suggestion-apply:hover {
+  background: rgba(120, 200, 255, 0.18);
+  color: rgba(160, 215, 255, 0.95);
+}

--- a/src/renderer/components/controls/command-palette.css
+++ b/src/renderer/components/controls/command-palette.css
@@ -604,3 +604,84 @@
   color: rgba(255, 100, 100, 0.7);
   font-size: 8px;
 }
+
+/* --- Unified query search (chip input + type-ahead) --- */
+
+.CommandPalette .commandPaletteSearch {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+/* The chip input lives inside a fixed-width floating palette: let chips wrap
+   and keep the field compact. query-input.css already styles the internals;
+   we only constrain width here. */
+.CommandPalette .commandPaletteSearch .query-input {
+  width: 100%;
+}
+
+/* In-place type-ahead results. Bounded height so a long match list scrolls
+   instead of overflowing the floating palette. */
+.CommandPalette .commandPaletteSearchResults {
+  margin-top: 6px;
+  max-height: 40vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.25);
+  padding: 4px;
+}
+
+/* Compact the shared suggestion-section rows for the tight palette. */
+.CommandPalette .commandPaletteSearchResults .suggestion-section {
+  margin-bottom: 6px;
+}
+
+.CommandPalette .commandPaletteSearchResults .suggestion-section-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: rgba(255, 255, 255, 0.4);
+  padding: 2px 6px;
+}
+
+.CommandPalette .commandPaletteSearchResults .suggestion-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+}
+
+.CommandPalette .commandPaletteSearchResults .suggestion-row:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.CommandPalette .commandPaletteSearchResults .suggestion-prefix {
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 11px;
+  flex: 0 0 auto;
+}
+
+.CommandPalette .commandPaletteSearchResults .suggestion-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.CommandPalette .commandPaletteSearchResults .suggestion-add-badge {
+  color: rgba(120, 200, 255, 0.9);
+  font-weight: 600;
+  flex: 0 0 auto;
+}
+
+.CommandPalette .commandPaletteSearchResults .suggestion-meta {
+  margin-left: auto;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.35);
+}

--- a/src/renderer/components/controls/command-palette.tsx
+++ b/src/renderer/components/controls/command-palette.tsx
@@ -350,8 +350,7 @@ const ListContextDisplay: React.FC<ListContextDisplayProps> = React.memo(
               onClick={(e) => {
                 stopAll(e);
                 libraryService.send({
-                  type: 'SET_TEXT_FILTER',
-                  data: { textFilter: '' },
+                  type: 'CLEAR_QUERY',
                 });
               }}
             >

--- a/src/renderer/components/controls/command-palette.tsx
+++ b/src/renderer/components/controls/command-palette.tsx
@@ -743,6 +743,22 @@ const CommandPalette: React.FC<CommandPaletteProps> = () => {
     }
   }, [display]);
 
+  // Focus the search input as soon as the palette is shown AND positioned, so
+  // the user can start typing immediately. We gate on positionReady (the
+  // palette renders visibility:hidden until then — a hidden element can't take
+  // focus) and defer one frame so the focus lands after paint and after the
+  // event that opened the palette, which could otherwise steal it back.
+  React.useEffect(() => {
+    if (!display || !positionReady) return undefined;
+    const raf = requestAnimationFrame(() => {
+      const input = paletteRef.current?.querySelector<HTMLInputElement>(
+        '.commandPaletteSearch input'
+      );
+      input?.focus();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [display, positionReady]);
+
   // Close on Click Outside.
   //
   // In trackpad/touchpad mode the detail view binds its own onClick

--- a/src/renderer/components/controls/command-palette.tsx
+++ b/src/renderer/components/controls/command-palette.tsx
@@ -551,13 +551,13 @@ const MenuContentArea: React.FC<MenuContentAreaProps> = React.memo(
 
     return (
       <div className="menuContent">
-        <CommandPaletteSearch libraryService={libraryService} />
         <ProgressBar
           value={cursor}
           total={libraryLength}
           isLoading={isLoading}
           setCursor={handleSetCursor}
         />
+        <CommandPaletteSearch libraryService={libraryService} />
 
         {renderTabContent()}
       </div>

--- a/src/renderer/components/controls/command-palette.tsx
+++ b/src/renderer/components/controls/command-palette.tsx
@@ -23,6 +23,7 @@ import DbPathWidget from './db-path';
 import GridSizePicker from './gridsize-picker';
 import CacheSetting from './cache-setting';
 import LoginWidget from './login-widget';
+import CommandPaletteSearch from './command-palette-search';
 
 // Assets (Icons)
 import soundIcon from '../../../../assets/sound-high.svg';
@@ -47,34 +48,6 @@ import { invoke, send, capabilities } from '../../platform';
 
 // Styles
 import './command-palette.css';
-
-// --- Helper Functions ---
-
-/**
- * Extracts the directory path from a full file path.
- * If the path is a file (has extension), returns the parent directory.
- * If the path is a directory (no extension), returns the path as-is.
- * @param path The full file path or directory path.
- * @returns The directory path.
- */
-function getDirectory(path: string): string {
-  if (!path) return '';
-  const separator = /[\\/]/;
-  const components = path.split(separator);
-  const lastComponent = components[components.length - 1];
-
-  // Check if the last component has a file extension
-  // A file extension is indicated by a dot followed by alphanumeric characters
-  const hasExtension = /\.[a-zA-Z0-9]+$/.test(lastComponent);
-
-  if (hasExtension) {
-    // It's a file, remove the filename to get the directory
-    components.pop();
-  }
-  // If no extension, assume it's already a directory path
-
-  return components.join('/');
-}
 
 // --- Types ---
 
@@ -114,12 +87,6 @@ interface ActionButtonsProps {
 interface MenuBarProps extends ActionButtonsProps {
   windowControlsProps: WindowControlsProps;
 }
-interface ListContextDisplayProps {
-  textFilter: string;
-  tags: string[];
-  activeDirectory: string;
-  libraryService: any;
-}
 interface SettingsListProps {
   filterType: 'image' | 'general' | 'autoplay' | 'listView';
   battleMode: boolean;
@@ -130,7 +97,6 @@ interface MenuContentAreaProps extends SettingsListProps {
   cursor: number;
   libraryLength: number;
   isLoading: boolean;
-  listContextProps: ListContextDisplayProps;
   libraryService: any; // Consider specific type
   storedCategories: { [key: string]: string };
   storedTags: { [key: string]: string[] };
@@ -323,80 +289,6 @@ const MenuBar: React.FC<MenuBarProps> = React.memo(
 );
 MenuBar.displayName = 'MenuBar'; // Add display name
 
-const ListContextDisplay: React.FC<ListContextDisplayProps> = React.memo(
-  ({ textFilter, tags, activeDirectory, libraryService }) => {
-    const hasTextFilter = !!textFilter;
-    const hasTags = Array.isArray(tags) && tags.length > 0;
-
-    // Stop the native event from reaching window-level listeners
-    // (specifically the palette's outside-click closer) so removing a
-    // pill never closes the palette as a side-effect.
-    const stopAll = (e: React.SyntheticEvent) => {
-      e.stopPropagation();
-      (e.nativeEvent as Event).stopImmediatePropagation?.();
-    };
-
-    if (hasTextFilter) {
-      return (
-        <span className="listContext">
-          <span className="contextPill contextPill--search">
-            <span className="contextPill__prefix">Search</span>
-            <span className="contextPill__label">{textFilter}</span>
-            <button
-              type="button"
-              className="contextPill__remove"
-              title="Clear search"
-              onMouseDown={stopAll}
-              onClick={(e) => {
-                stopAll(e);
-                libraryService.send({
-                  type: 'CLEAR_QUERY',
-                });
-              }}
-            >
-              ×
-            </button>
-          </span>
-        </span>
-      );
-    }
-
-    if (hasTags) {
-      return (
-        <span className="listContext">
-          {tags.map((tag) => (
-            <span key={tag} className="contextPill contextPill--tag">
-              <span className="contextPill__label">{tag}</span>
-              <button
-                type="button"
-                className="contextPill__remove"
-                title={`Remove ${tag}`}
-                onMouseDown={stopAll}
-                onClick={(e) => {
-                  stopAll(e);
-                  libraryService.send({
-                    type: 'REMOVE_QUERY_TAG',
-                    data: { tag },
-                  });
-                }}
-              >
-                ×
-              </button>
-            </span>
-          ))}
-        </span>
-      );
-    }
-
-    return (
-      <span className="listContext">
-        {getDirectory(activeDirectory) || 'No Context'}
-      </span>
-    );
-  }
-);
-ListContextDisplay.displayName = 'ListContextDisplay'; // Add display name
-
 const SettingsList: React.FC<SettingsListProps> = React.memo(
   ({ filterType, battleMode, currentItem }) => {
     const settingKeys = useMemo(() => {
@@ -575,7 +467,6 @@ const MenuContentArea: React.FC<MenuContentAreaProps> = React.memo(
     cursor,
     libraryLength,
     isLoading,
-    listContextProps,
     libraryService,
     battleMode,
     currentItem,
@@ -660,7 +551,7 @@ const MenuContentArea: React.FC<MenuContentAreaProps> = React.memo(
 
     return (
       <div className="menuContent">
-        <ListContextDisplay {...listContextProps} />
+        <CommandPaletteSearch libraryService={libraryService} />
         <ProgressBar
           value={cursor}
           total={libraryLength}
@@ -746,17 +637,9 @@ const CommandPalette: React.FC<CommandPaletteProps> = () => {
   );
 
   // Selectors for Library and Settings State
-  const tags = useSelector(
-    libraryService,
-    (state) => state.context.dbQuery.tags
-  );
   const textFilter = useSelector(
     libraryService,
     (state) => state.context.textFilter
-  );
-  const activeDirectory = useSelector(
-    libraryService,
-    (state) => state.context.initialFile
   );
   const cursor = useSelector(libraryService, (state) => state.context.cursor);
   const settings = useSelector(
@@ -932,20 +815,12 @@ const CommandPalette: React.FC<CommandPaletteProps> = () => {
     alwaysOnTop: settings.alwaysOnTop,
   };
 
-  const listContextProps: ListContextDisplayProps = {
-    textFilter,
-    tags,
-    activeDirectory,
-    libraryService,
-  };
-
   const menuContentAreaProps: Omit<
     MenuContentAreaProps,
     | 'activeTab'
     | 'cursor'
     | 'libraryLength'
     | 'isLoading'
-    | 'listContextProps'
     | 'libraryService'
   > = {
     battleMode: settings.battleMode,
@@ -986,7 +861,6 @@ const CommandPalette: React.FC<CommandPaletteProps> = () => {
           cursor={cursor}
           libraryLength={library.length}
           isLoading={isLoading}
-          listContextProps={listContextProps}
           libraryService={libraryService}
           {...menuContentAreaProps} // Pass battleMode and currentItem
         />

--- a/src/renderer/components/controls/command-palette.tsx
+++ b/src/renderer/components/controls/command-palette.tsx
@@ -557,7 +557,10 @@ const MenuContentArea: React.FC<MenuContentAreaProps> = React.memo(
           isLoading={isLoading}
           setCursor={handleSetCursor}
         />
-        <CommandPaletteSearch libraryService={libraryService} />
+        <CommandPaletteSearch
+          libraryService={libraryService}
+          currentItem={currentItem}
+        />
 
         {renderTabContent()}
       </div>

--- a/src/renderer/components/controls/context-palette.tsx
+++ b/src/renderer/components/controls/context-palette.tsx
@@ -12,6 +12,7 @@ import { GlobalStateContext } from '../../state';
 import useOnClickOutside from '../../hooks/useOnClickOutside';
 import filter from '../../filter';
 import LoginWidget from './login-widget';
+import { getDirFromInitialFile, buildLibraryPathQuery } from './context-query';
 import './context-palette.css';
 
 type ActionDef = {
@@ -80,22 +81,6 @@ type ContextTarget =
   | { type: 'tag'; tag: string }
   | { type: 'category'; category: string };
 
-/** If initialFile is a media file path, return its parent directory; otherwise return as-is. */
-function getDirFromInitialFile(initialFile: string): string {
-  const lastSegment = initialFile.split(/[/\\]/).pop() || '';
-  if (lastSegment.includes('.')) {
-    const sep = initialFile.includes('\\') ? '\\' : '/';
-    const idx = initialFile.lastIndexOf(sep);
-    let dir = idx > 0 ? initialFile.slice(0, idx) : initialFile;
-    // Ensure Windows drive-letter roots keep their trailing separator (e.g. "D:" → "D:\")
-    if (/^[A-Za-z]:$/.test(dir)) {
-      dir += sep;
-    }
-    return dir;
-  }
-  return initialFile;
-}
-
 // Wrap a tag/category value in double quotes so multi-word values (e.g.
 // "Exchange Student") survive query parsing. Without quotes the server lexer
 // splits on the space and the query fails to parse — which historically caused
@@ -112,7 +97,7 @@ function buildQuery(
     dbQuery: { tags: string[] };
     textFilter: string;
     initialFile: string;
-    settings: { filteringMode: string };
+    settings: { filteringMode: string; recursive: boolean };
   }
 ): string {
   switch (target.type) {
@@ -130,7 +115,10 @@ function buildQuery(
           settings.filteringMode === 'EXCLUSIVE' ? ' AND ' : ' OR ';
         return dbQuery.tags.map((t) => `tag:${quoteValue(t)}`).join(joiner);
       }
-      return `pathdir:"${getDirFromInitialFile(initialFile)}"`;
+      // Filesystem context: match the current list view. When recursive
+      // browsing is on the list spans subdirectories, so match every path
+      // under the directory; otherwise match only its immediate children.
+      return buildLibraryPathQuery(initialFile, settings.recursive);
     }
   }
 }
@@ -401,6 +389,10 @@ export default function ContextPalette() {
     libraryService,
     (state) => state.context.settings.filteringMode
   );
+  const recursive = useSelector(
+    libraryService,
+    (state) => state.context.settings.recursive
+  );
   const library = useSelector(
     libraryService,
     (state) => state.context.library
@@ -540,7 +532,7 @@ export default function ContextPalette() {
     dbQuery,
     textFilter,
     initialFile,
-    settings: { filteringMode },
+    settings: { filteringMode, recursive },
   };
   const items = filter(libraryLoadId, textFilter, library, filters, sortBy);
   const itemCount = target.type === 'file' ? 1 : items.length;

--- a/src/renderer/components/controls/context-palette.tsx
+++ b/src/renderer/components/controls/context-palette.tsx
@@ -108,7 +108,7 @@ function quoteValue(value: string): string {
 function buildQuery(
   target: ContextTarget,
   libraryContext: {
-    currentStateType: 'fs' | 'db' | 'search';
+    currentStateType: 'fs' | 'db';
     dbQuery: { tags: string[] };
     textFilter: string;
     initialFile: string;
@@ -123,21 +123,12 @@ function buildQuery(
     case 'category':
       return `category:${quoteValue(target.category)}`;
     case 'library': {
-      const { currentStateType, dbQuery, textFilter, initialFile, settings } =
+      const { currentStateType, dbQuery, initialFile, settings } =
         libraryContext;
       if (currentStateType === 'db' && dbQuery.tags.length > 0) {
         const joiner =
           settings.filteringMode === 'EXCLUSIVE' ? ' AND ' : ' OR ';
         return dbQuery.tags.map((t) => `tag:${quoteValue(t)}`).join(joiner);
-      }
-      if (currentStateType === 'search' && textFilter) {
-        const parts: string[] = [`description:${textFilter}`];
-        if (dbQuery.tags.length > 0) {
-          const joiner =
-            settings.filteringMode === 'EXCLUSIVE' ? ' AND ' : ' OR ';
-          parts.push(dbQuery.tags.map((t) => `tag:${t}`).join(joiner));
-        }
-        return parts.join(' AND ');
       }
       return `pathdir:"${getDirFromInitialFile(initialFile)}"`;
     }
@@ -147,7 +138,7 @@ function buildQuery(
 function buildLabel(
   target: ContextTarget,
   libraryContext: {
-    currentStateType: 'fs' | 'db' | 'search';
+    currentStateType: 'fs' | 'db';
     dbQuery: { tags: string[] };
     textFilter: string;
     initialFile: string;
@@ -163,13 +154,10 @@ function buildLabel(
     case 'category':
       return `Category: ${target.category}`;
     case 'library': {
-      const { currentStateType, dbQuery, textFilter, initialFile } =
+      const { currentStateType, dbQuery, initialFile } =
         libraryContext;
       if (currentStateType === 'db' && dbQuery.tags.length > 0) {
         return `${dbQuery.tags.length} tag${dbQuery.tags.length !== 1 ? 's' : ''} selected`;
-      }
-      if (currentStateType === 'search' && textFilter) {
-        return `Search: ${textFilter}`;
       }
       const dir = getDirFromInitialFile(initialFile);
       return `Directory: ${dir.split(/[/\\]/).filter(Boolean).pop() || dir}`;
@@ -560,8 +548,7 @@ export default function ContextPalette() {
   const queryString = buildQuery(target, libraryCtx);
   const isFolderContext =
     target.type === 'library' &&
-    !(currentStateType === 'db' && dbQuery.tags.length > 0) &&
-    !(currentStateType === 'search' && textFilter);
+    !(currentStateType === 'db' && dbQuery.tags.length > 0);
   const encodeQuery64 = (q: string) =>
     btoa(
       new TextEncoder()

--- a/src/renderer/components/controls/context-palette.tsx
+++ b/src/renderer/components/controls/context-palette.tsx
@@ -96,6 +96,15 @@ function getDirFromInitialFile(initialFile: string): string {
   return initialFile;
 }
 
+// Wrap a tag/category value in double quotes so multi-word values (e.g.
+// "Exchange Student") survive query parsing. Without quotes the server lexer
+// splits on the space and the query fails to parse — which historically caused
+// the whole library to be selected. Embedded quotes are escaped to keep the
+// token well-formed.
+function quoteValue(value: string): string {
+  return `"${value.replace(/"/g, '\\"')}"`;
+}
+
 function buildQuery(
   target: ContextTarget,
   libraryContext: {
@@ -110,16 +119,16 @@ function buildQuery(
     case 'file':
       return `path:"${target.path}"`;
     case 'tag':
-      return `tag:${target.tag}`;
+      return `tag:${quoteValue(target.tag)}`;
     case 'category':
-      return `category:${target.category}`;
+      return `category:${quoteValue(target.category)}`;
     case 'library': {
       const { currentStateType, dbQuery, textFilter, initialFile, settings } =
         libraryContext;
       if (currentStateType === 'db' && dbQuery.tags.length > 0) {
         const joiner =
           settings.filteringMode === 'EXCLUSIVE' ? ' AND ' : ' OR ';
-        return dbQuery.tags.map((t) => `tag:${t}`).join(joiner);
+        return dbQuery.tags.map((t) => `tag:${quoteValue(t)}`).join(joiner);
       }
       if (currentStateType === 'search' && textFilter) {
         const parts: string[] = [`description:${textFilter}`];

--- a/src/renderer/components/controls/context-query.ts
+++ b/src/renderer/components/controls/context-query.ts
@@ -1,0 +1,44 @@
+// Pure query-string builders for the context palette. Kept in their own module
+// (no XState / platform imports) so they can be unit-tested directly without
+// dragging in the renderer's state/platform module graph.
+
+/** If initialFile is a media file path, return its parent directory; otherwise return as-is. */
+export function getDirFromInitialFile(initialFile: string): string {
+  const lastSegment = initialFile.split(/[/\\]/).pop() || '';
+  if (lastSegment.includes('.')) {
+    const sep = initialFile.includes('\\') ? '\\' : '/';
+    const idx = initialFile.lastIndexOf(sep);
+    let dir = idx > 0 ? initialFile.slice(0, idx) : initialFile;
+    // Ensure Windows drive-letter roots keep their trailing separator (e.g. "D:" → "D:\")
+    if (/^[A-Za-z]:$/.test(dir)) {
+      dir += sep;
+    }
+    return dir;
+  }
+  return initialFile;
+}
+
+/**
+ * Build the path query for a filesystem-loaded library context so it matches
+ * the *current* list view.
+ *
+ * - Non-recursive: `pathdir:"dir"` matches files directly inside the directory
+ *   only (server expands it to `LIKE 'dir/%' AND NOT LIKE 'dir/%/%'`).
+ * - Recursive: the list view includes files from every subdirectory, so the
+ *   query must match all paths *under* the directory. We emit a trailing-`*`
+ *   wildcard, which the server's query lexer turns into a prefixed LIKE
+ *   (`path:"dir/*"` → `m.path LIKE 'dir/%'`) — exactly the nested rows the
+ *   `pathdir` form deliberately excludes via its `NOT LIKE 'dir/%/%'` clause.
+ */
+export function buildLibraryPathQuery(
+  initialFile: string,
+  recursive: boolean
+): string {
+  const dir = getDirFromInitialFile(initialFile);
+  if (!recursive) {
+    return `pathdir:"${dir}"`;
+  }
+  const sep = dir.includes('\\') ? '\\' : '/';
+  const base = dir.endsWith(sep) ? dir : dir + sep;
+  return `path:"${base}*"`;
+}

--- a/src/renderer/components/controls/hotkey-controller.tsx
+++ b/src/renderer/components/controls/hotkey-controller.tsx
@@ -566,6 +566,22 @@ export default function HotKeyController() {
   );
 
   const handleKeyDown = (e: KeyboardEvent) => {
+    // While a text input / editable is focused, disable ALL hotkeys (incl. the
+    // shift/control toggle actions and ctrl-combos below) so typing a query in
+    // the search bar or command palette never triggers app shortcuts. Escape
+    // is still allowed through so surfaces can dismiss.
+    const focusTarget = e.target as HTMLElement | null;
+    const isEditing =
+      !!focusTarget &&
+      (focusTarget.tagName === 'INPUT' ||
+        focusTarget.tagName === 'TEXTAREA' ||
+        focusTarget.isContentEditable ||
+        focusTarget.classList?.contains('time-input') ||
+        focusTarget.classList?.contains('text-input'));
+    if (isEditing && e.key.toLowerCase() !== 'escape') {
+      return;
+    }
+
     let mainKey = e.key.toLowerCase();
 
     // Use e.code for digits to ensure consistent behavior across different keyboard layouts
@@ -608,21 +624,7 @@ export default function HotKeyController() {
       return;
     }
 
-    // Check if we're currently focused on any input element
-    const target = e.target as HTMLElement;
-    const isInputElement =
-      target &&
-      (target.tagName === 'INPUT' ||
-        target.tagName === 'TEXTAREA' ||
-        target.contentEditable === 'true' ||
-        target.classList.contains('time-input') ||
-        target.classList.contains('text-input'));
-
-    // For most keys, if we're in an input element, let the input handle it
-    // Exception: Allow Ctrl+combinations and Escape to still work for shortcuts
-    if (isInputElement && !e.ctrlKey && !e.metaKey && mainKey !== 'escape') {
-      return; // Let the input handle the key
-    }
+    // (Input-focus is handled by the early guard at the top of this handler.)
 
     const keys: string[] = [mainKey === 'space' ? ' ' : mainKey];
 

--- a/src/renderer/components/controls/video-controls.css
+++ b/src/renderer/components/controls/video-controls.css
@@ -80,6 +80,26 @@
   opacity: 1;
 }
 
+/* Frame-step buttons show a text label ("−1f"/"+1f") rather than an icon, so
+   they opt out of the icon-oriented invert filter and set their own color. */
+.frame-step-button {
+  filter: none;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 11px;
+  font-weight: 600;
+  min-width: 30px;
+  font-variant-numeric: tabular-nums;
+}
+
+.frame-step-button:hover {
+  color: #fff;
+}
+
+.frame-step-button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 .progressBar {
   width: 100%;
   height: 16px; /* Increased hit area for better interaction */

--- a/src/renderer/components/controls/video-controls.css
+++ b/src/renderer/components/controls/video-controls.css
@@ -80,25 +80,6 @@
   opacity: 1;
 }
 
-/* Frame-step buttons show a text label ("−1f"/"+1f") rather than an icon, so
-   they opt out of the icon-oriented invert filter and set their own color. */
-.frame-step-button {
-  filter: none;
-  color: rgba(255, 255, 255, 0.9);
-  font-size: 11px;
-  font-weight: 600;
-  min-width: 30px;
-  font-variant-numeric: tabular-nums;
-}
-
-.frame-step-button:hover {
-  color: #fff;
-}
-
-.frame-step-button:disabled {
-  opacity: 0.4;
-  cursor: default;
-}
 
 .progressBar {
   width: 100%;
@@ -246,6 +227,78 @@
   font-size: 11px;
   font-weight: 500;
   opacity: 0.8;
+}
+
+/* Frame/transport popover above the play button (same hover model + look as the
+   volume popover). */
+.VideoControls .playButtonContainer {
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding-top: 15px; /* Space for the popover */
+  margin-top: -15px; /* Compensate so the button doesn't shift */
+}
+
+.VideoControls .playButtonContainer .frameControlHover {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.7);
+  padding: 10px;
+  border-radius: 8px;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  z-index: 10001;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: all;
+}
+
+.frameControlHover .popover-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.frameControlHover .popover-label {
+  color: white;
+  font-size: 11px;
+  font-weight: 500;
+  opacity: 0.8;
+  margin-right: 2px;
+}
+
+.frameControlHover .popover-button {
+  filter: none;
+  border: none;
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 7px;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  transition: background 0.15s, color 0.15s;
+}
+
+.frameControlHover .popover-button:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+.frameControlHover .popover-button.selected {
+  background: rgba(255, 255, 255, 0.28);
+  color: #fff;
+}
+
+.frameControlHover .popover-button:disabled {
+  opacity: 0.4;
+  cursor: default;
 }
 
 .volumeSliderHover {

--- a/src/renderer/components/controls/video-controls.tsx
+++ b/src/renderer/components/controls/video-controls.tsx
@@ -20,6 +20,7 @@ import {
   pixelToTime,
   selectDisplayTime,
   coalescedSeekTarget,
+  seekBy,
 } from '../../video-frame';
 import './video-controls.css';
 
@@ -101,8 +102,14 @@ interface VideoControlsProps {
 
 export default function VideoControls({ mediaRef }: VideoControlsProps = {}) {
   const { libraryService } = useContext(GlobalStateContext);
-  const { actualVideoTime, videoLength, loopLength, playing, frameRate } =
-    useSelector(libraryService, (state) => state.context.videoPlayer);
+  const {
+    actualVideoTime,
+    videoLength,
+    loopLength,
+    playing,
+    frameRate,
+    playbackRate,
+  } = useSelector(libraryService, (state) => state.context.videoPlayer);
   const { volume, playSound } = useSelector(
     libraryService,
     (state: any) => state.context.settings
@@ -116,6 +123,14 @@ export default function VideoControls({ mediaRef }: VideoControlsProps = {}) {
   const volumeContainerRef = useRef<HTMLDivElement>(null);
   const [hoverTime, setHoverTime] = useState<number | null>(null);
   const [hoverPosition, setHoverPosition] = useState(0);
+
+  // Frame/transport popover: opens after hovering the play button for 3s (long
+  // enough that it doesn't pop up during normal play/pause clicks), and stays
+  // open while the cursor is over the button or the popover — same hover model
+  // as the volume control.
+  const [showFrameControls, setShowFrameControls] = useState(false);
+  const playContainerRef = useRef<HTMLDivElement>(null);
+  const playHoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Refs for smoother scrubbing logic
   const wasPlayingRef = useRef(false); // Store playing state before drag
@@ -199,6 +214,43 @@ export default function VideoControls({ mediaRef }: VideoControlsProps = {}) {
     handleSettingChange('playSound', !playSound);
   }, [playSound, handleSettingChange]);
 
+  // --- Frame/transport popover hover logic (3s open delay) ---
+  const handlePlayMouseEnter = useCallback(() => {
+    if (playHoverTimerRef.current) clearTimeout(playHoverTimerRef.current);
+    playHoverTimerRef.current = setTimeout(() => {
+      setShowFrameControls(true);
+    }, 3000);
+  }, []);
+
+  const handlePlayMouseLeave = useCallback(() => {
+    if (playHoverTimerRef.current) {
+      clearTimeout(playHoverTimerRef.current);
+      playHoverTimerRef.current = null;
+    }
+    // Brief grace period so the cursor can travel from the button into the
+    // popover without it closing.
+    setTimeout(() => {
+      if (!playContainerRef.current?.matches(':hover')) {
+        setShowFrameControls(false);
+      }
+    }, 120);
+  }, []);
+
+  const handlePlayContainerMouseLeave = useCallback(() => {
+    if (playHoverTimerRef.current) {
+      clearTimeout(playHoverTimerRef.current);
+      playHoverTimerRef.current = null;
+    }
+    setShowFrameControls(false);
+  }, []);
+
+  // Clear any pending open timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (playHoverTimerRef.current) clearTimeout(playHoverTimerRef.current);
+    };
+  }, []);
+
   // --- Scrubbing Logic ---
 
   const handleProgressHover = useCallback(
@@ -267,6 +319,39 @@ export default function VideoControls({ mediaRef }: VideoControlsProps = {}) {
       });
     },
     [videoLength, playing, actualVideoTime, frameRate, libraryService, mediaRef]
+  );
+
+  // Skip forward/back by a fixed number of seconds (rewind / fast-forward),
+  // clamped to the clip. Seeks the element directly and syncs the machine.
+  const SKIP_SECONDS = 10;
+  const skip = useCallback(
+    (deltaSeconds: number) => {
+      if (videoLength <= 0) return;
+      const target = seekBy(actualVideoTime, deltaSeconds, videoLength);
+      const el = mediaRef?.current;
+      if (el) el.currentTime = target;
+      libraryService.send('SET_VIDEO_TIME', {
+        timeStamp: target,
+        eventId: uniqueId(),
+      });
+      libraryService.send('SET_ACTUAL_VIDEO_TIME', {
+        timeStamp: target,
+        eventId: uniqueId(),
+      });
+    },
+    [videoLength, actualVideoTime, libraryService, mediaRef]
+  );
+
+  // Set the playback speed. Applies to the element immediately and persists in
+  // the machine so it survives clip changes within the session.
+  const PLAYBACK_SPEEDS = [0.25, 0.5, 1, 1.5, 2];
+  const setSpeed = useCallback(
+    (rate: number) => {
+      const el = mediaRef?.current;
+      if (el) el.playbackRate = rate;
+      libraryService.send('SET_PLAYBACK_RATE', { playbackRate: rate });
+    },
+    [libraryService, mediaRef]
   );
 
   // Arrow keys step one frame while the slider is focused. Scoped to the slider
@@ -448,39 +533,94 @@ export default function VideoControls({ mediaRef }: VideoControlsProps = {}) {
   return (
     <div className="VideoControls">
       <div className="controls-left">
-        <button
-          className="control-button frame-step-button"
-          onClick={() => stepFrame(-1)}
-          disabled={videoLength <= 0}
-          aria-label="Previous frame"
-          title="Previous frame (←)"
+        <div
+          className="playButtonContainer"
+          ref={playContainerRef}
+          onMouseLeave={handlePlayContainerMouseLeave}
         >
-          <span>−1f</span>
-        </button>
-        <button
-          className="control-button"
-          onClick={() => {
-            libraryService.send('SET_PLAYING_STATE', {
-              playing: !playing,
-            });
-          }}
-          aria-label={playing ? 'Pause' : 'Play'}
-        >
-          {playing ? (
-            <img src={pause} alt="Pause" />
-          ) : (
-            <img src={play} alt="Play" />
+          <button
+            className="control-button"
+            onClick={() => {
+              libraryService.send('SET_PLAYING_STATE', {
+                playing: !playing,
+              });
+            }}
+            onMouseEnter={handlePlayMouseEnter}
+            onMouseLeave={handlePlayMouseLeave}
+            aria-label={playing ? 'Pause' : 'Play'}
+          >
+            {playing ? (
+              <img src={pause} alt="Pause" />
+            ) : (
+              <img src={play} alt="Play" />
+            )}
+          </button>
+          {showFrameControls && (
+            // Stop click/double-click from reaching the detail panel, whose
+            // double-click handler collapses panels (switches to list view) —
+            // fast clicks here must not trigger it.
+            <div
+              className="frameControlHover"
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
+              onDoubleClick={(e) => e.stopPropagation()}
+            >
+              <div className="popover-row">
+                <span className="popover-label">Speed</span>
+                {PLAYBACK_SPEEDS.map((rate) => (
+                  <button
+                    key={rate}
+                    className={`popover-button speed-button${
+                      playbackRate === rate ? ' selected' : ''
+                    }`}
+                    onClick={() => setSpeed(rate)}
+                    aria-pressed={playbackRate === rate}
+                  >
+                    {rate}×
+                  </button>
+                ))}
+              </div>
+              <div className="popover-row">
+                <button
+                  className="popover-button transport-button"
+                  onClick={() => skip(-SKIP_SECONDS)}
+                  disabled={videoLength <= 0}
+                  aria-label={`Rewind ${SKIP_SECONDS} seconds`}
+                  title={`Rewind ${SKIP_SECONDS}s`}
+                >
+                  «{SKIP_SECONDS}s
+                </button>
+                <button
+                  className="popover-button transport-button"
+                  onClick={() => stepFrame(-1)}
+                  disabled={videoLength <= 0}
+                  aria-label="Previous frame"
+                  title="Previous frame (←)"
+                >
+                  −1f
+                </button>
+                <button
+                  className="popover-button transport-button"
+                  onClick={() => stepFrame(1)}
+                  disabled={videoLength <= 0}
+                  aria-label="Next frame"
+                  title="Next frame (→)"
+                >
+                  +1f
+                </button>
+                <button
+                  className="popover-button transport-button"
+                  onClick={() => skip(SKIP_SECONDS)}
+                  disabled={videoLength <= 0}
+                  aria-label={`Fast-forward ${SKIP_SECONDS} seconds`}
+                  title={`Fast-forward ${SKIP_SECONDS}s`}
+                >
+                  {SKIP_SECONDS}s»
+                </button>
+              </div>
+            </div>
           )}
-        </button>
-        <button
-          className="control-button frame-step-button"
-          onClick={() => stepFrame(1)}
-          disabled={videoLength <= 0}
-          aria-label="Next frame"
-          title="Next frame (→)"
-        >
-          <span>+1f</span>
-        </button>
+        </div>
       </div>
 
       <div className="controls-center">

--- a/src/renderer/components/controls/video-controls.tsx
+++ b/src/renderer/components/controls/video-controls.tsx
@@ -15,6 +15,7 @@ import soundOff from '../../../../assets/sound-off.svg';
 import { uniqueId } from 'xstate/lib/utils';
 import { GlobalStateContext } from '../../state';
 import AudioTrackControls from './audio-track-controls';
+import { frameStep, pixelToTime } from '../../video-frame';
 import './video-controls.css';
 
 // --- Helper Functions (mapRange, getLabel, useElementSize - remain the same) ---
@@ -88,10 +89,8 @@ function getLabel(currentVideoTimeStamp: number): string {
 
 export default function VideoControls() {
   const { libraryService } = useContext(GlobalStateContext);
-  const { actualVideoTime, videoLength, loopLength, playing } = useSelector(
-    libraryService,
-    (state) => state.context.videoPlayer
-  );
+  const { actualVideoTime, videoLength, loopLength, playing, frameRate } =
+    useSelector(libraryService, (state) => state.context.videoPlayer);
   const { volume, playSound } = useSelector(
     libraryService,
     (state: any) => state.context.settings
@@ -177,6 +176,44 @@ export default function VideoControls() {
     setHoverTime(null);
   }, []);
 
+  // Step exactly one frame. Frame inspection implies a paused video, so pause
+  // first if playing, then seek to the fractional frame time. frameStep falls
+  // back to 30fps when the detected rate is unknown (see video-frame.ts).
+  const stepFrame = useCallback(
+    (direction: 1 | -1) => {
+      if (videoLength <= 0) return;
+      if (playing) {
+        libraryService.send('SET_PLAYING_STATE', { playing: false });
+      }
+      const target = frameStep(
+        actualVideoTime,
+        frameRate,
+        direction,
+        videoLength
+      );
+      libraryService.send('SET_VIDEO_TIME', {
+        timeStamp: target,
+        eventId: uniqueId(),
+      });
+    },
+    [videoLength, playing, actualVideoTime, frameRate, libraryService]
+  );
+
+  // Arrow keys step one frame while the slider is focused. Scoped to the slider
+  // (rather than global) so it never hijacks arrow-key media navigation.
+  const handleSliderKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        stepFrame(1);
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        stepFrame(-1);
+      }
+    },
+    [stepFrame]
+  );
+
   // Function to perform the actual time update (called within rAF)
   const performTimeUpdate = useCallback(() => {
     if (!progressBarRef.current || progressBarWidth <= 0 || videoLength <= 0) {
@@ -187,13 +224,14 @@ export default function VideoControls() {
     const rect = progressBarRef.current.getBoundingClientRect();
     const offsetX = latestMouseXRef.current - rect.left;
 
-    const newTimeStamp = Math.round(
-      mapRange(offsetX, 0, progressBarWidth, 0, videoLength)
-    );
+    // Fractional seek target — NOT rounded to whole seconds. The previous
+    // Math.round + 0.05 gate is exactly what limited scrubbing to one-second
+    // steps. rAF already throttles sends to ~display rate.
+    const newTimeStamp = pixelToTime(offsetX, progressBarWidth, videoLength);
 
-    // Only send update if time actually changed noticeably to prevent flooding
-    // Allow small threshold for smoother seeking start/end
-    if (Math.abs(newTimeStamp - actualVideoTime) > 0.05) {
+    // Suppress only truly redundant sends (sub-millisecond), so single-frame
+    // drag movements still go through.
+    if (Math.abs(newTimeStamp - actualVideoTime) > 0.001) {
       libraryService.send('SET_VIDEO_TIME', {
         timeStamp: newTimeStamp,
         eventId: uniqueId(), // Consider if uniqueId is needed here
@@ -283,8 +321,10 @@ export default function VideoControls() {
       ) {
         const rect = progressBarRef.current.getBoundingClientRect();
         const offsetX = e.clientX - rect.left;
-        const finalTimeStamp = Math.round(
-          mapRange(offsetX, 0, progressBarWidth, 0, videoLength)
+        const finalTimeStamp = pixelToTime(
+          offsetX,
+          progressBarWidth,
+          videoLength
         );
         libraryService.send('LOOP_VIDEO', {
           loopStartTime: finalTimeStamp,
@@ -331,6 +371,15 @@ export default function VideoControls() {
     <div className="VideoControls">
       <div className="controls-left">
         <button
+          className="control-button frame-step-button"
+          onClick={() => stepFrame(-1)}
+          disabled={videoLength <= 0}
+          aria-label="Previous frame"
+          title="Previous frame (←)"
+        >
+          <span>−1f</span>
+        </button>
+        <button
           className="control-button"
           onClick={() => {
             libraryService.send('SET_PLAYING_STATE', {
@@ -344,6 +393,15 @@ export default function VideoControls() {
           ) : (
             <img src={play} alt="Play" />
           )}
+        </button>
+        <button
+          className="control-button frame-step-button"
+          onClick={() => stepFrame(1)}
+          disabled={videoLength <= 0}
+          aria-label="Next frame"
+          title="Next frame (→)"
+        >
+          <span>+1f</span>
         </button>
       </div>
 
@@ -361,6 +419,7 @@ export default function VideoControls() {
             aria-valuenow={actualVideoTime || 0}
             aria-valuetext={getLabel(actualVideoTime || 0)}
             tabIndex={0} // Make focusable
+            onKeyDown={handleSliderKeyDown}
             onMouseMove={handleProgressHover}
             onMouseLeave={handleProgressLeave}
           >

--- a/src/renderer/components/controls/video-controls.tsx
+++ b/src/renderer/components/controls/video-controls.tsx
@@ -124,7 +124,7 @@ export default function VideoControls({ mediaRef }: VideoControlsProps = {}) {
   const [hoverTime, setHoverTime] = useState<number | null>(null);
   const [hoverPosition, setHoverPosition] = useState(0);
 
-  // Frame/transport popover: opens after hovering the play button for 3s (long
+  // Frame/transport popover: opens after hovering the play button for 1s (long
   // enough that it doesn't pop up during normal play/pause clicks), and stays
   // open while the cursor is over the button or the popover — same hover model
   // as the volume control.
@@ -219,7 +219,7 @@ export default function VideoControls({ mediaRef }: VideoControlsProps = {}) {
     if (playHoverTimerRef.current) clearTimeout(playHoverTimerRef.current);
     playHoverTimerRef.current = setTimeout(() => {
       setShowFrameControls(true);
-    }, 3000);
+    }, 1000);
   }, []);
 
   const handlePlayMouseLeave = useCallback(() => {

--- a/src/renderer/components/controls/video-controls.tsx
+++ b/src/renderer/components/controls/video-controls.tsx
@@ -15,7 +15,12 @@ import soundOff from '../../../../assets/sound-off.svg';
 import { uniqueId } from 'xstate/lib/utils';
 import { GlobalStateContext } from '../../state';
 import AudioTrackControls from './audio-track-controls';
-import { frameStep, pixelToTime } from '../../video-frame';
+import {
+  frameStep,
+  pixelToTime,
+  selectDisplayTime,
+  coalescedSeekTarget,
+} from '../../video-frame';
 import './video-controls.css';
 
 // --- Helper Functions (mapRange, getLabel, useElementSize - remain the same) ---
@@ -87,7 +92,14 @@ function getLabel(currentVideoTimeStamp: number): string {
 
 // --- Component ---
 
-export default function VideoControls() {
+interface VideoControlsProps {
+  // The media element being controlled. When supplied, scrubbing seeks the
+  // element directly (fast, coalesced, no per-frame XState churn). When absent,
+  // the component falls back to the XState SET_VIDEO_TIME path.
+  mediaRef?: React.RefObject<HTMLMediaElement>;
+}
+
+export default function VideoControls({ mediaRef }: VideoControlsProps = {}) {
   const { libraryService } = useContext(GlobalStateContext);
   const { actualVideoTime, videoLength, loopLength, playing, frameRate } =
     useSelector(libraryService, (state) => state.context.videoPlayer);
@@ -109,6 +121,52 @@ export default function VideoControls() {
   const wasPlayingRef = useRef(false); // Store playing state before drag
   const rafRef = useRef<number | null>(null); // Store requestAnimationFrame ID
   const latestMouseXRef = useRef(0); // Store latest mouse position for rAF
+
+  // Optimistic scrub position. While dragging, the thumb/label render from this
+  // (cursor-locked, instant) instead of actualVideoTime (which only updates
+  // after the seek decodes) — this is what makes scrubbing feel direct.
+  const [dragTime, setDragTime] = useState<number | null>(null);
+  // Latest requested seek time; the `seeked` handler converges to it so we keep
+  // exactly one seek in flight (see coalescedSeekTarget).
+  const pendingSeekRef = useRef<number | null>(null);
+  // Live mirror of actualVideoTime read inside drag callbacks, so those
+  // callbacks (and the global mouse-listener effect) don't re-create every time
+  // actualVideoTime ticks mid-drag — which would re-subscribe the listeners.
+  const actualVideoTimeRef = useRef(actualVideoTime);
+  actualVideoTimeRef.current = actualVideoTime;
+
+  const displayTime = selectDisplayTime(isDragging, dragTime, actualVideoTime);
+
+  // Seek the media element directly with coalescing. Returns false when no
+  // element is available so callers can fall back to the XState path.
+  const seekElement = useCallback(
+    (time: number): boolean => {
+      const el = mediaRef?.current;
+      if (!el) return false;
+      pendingSeekRef.current = time;
+      const target = coalescedSeekTarget(time, el.seeking, el.currentTime);
+      if (target != null) el.currentTime = target;
+      return true;
+    },
+    [mediaRef]
+  );
+
+  // When a coalesced seek completes, immediately seek to the most recent
+  // pending target if the cursor has moved on. Active only during a drag.
+  useEffect(() => {
+    const el = mediaRef?.current;
+    if (!el || !isDragging) return;
+    const onSeeked = () => {
+      const target = coalescedSeekTarget(
+        pendingSeekRef.current,
+        el.seeking,
+        el.currentTime
+      );
+      if (target != null) el.currentTime = target;
+    };
+    el.addEventListener('seeked', onSeeked);
+    return () => el.removeEventListener('seeked', onSeeked);
+  }, [mediaRef, isDragging]);
 
   // --- Volume Logic ---
   const handleSettingChange = useCallback(
@@ -191,12 +249,24 @@ export default function VideoControls() {
         direction,
         videoLength
       );
+      // Seek the element directly for an instant step, then sync the machine
+      // (and every actualVideoTime consumer) to the new position so the thumb
+      // and readout update without waiting on the seek round-trip.
+      const el = mediaRef?.current;
+      if (el) {
+        el.pause();
+        el.currentTime = target;
+      }
       libraryService.send('SET_VIDEO_TIME', {
         timeStamp: target,
         eventId: uniqueId(),
       });
+      libraryService.send('SET_ACTUAL_VIDEO_TIME', {
+        timeStamp: target,
+        eventId: uniqueId(),
+      });
     },
-    [videoLength, playing, actualVideoTime, frameRate, libraryService]
+    [videoLength, playing, actualVideoTime, frameRate, libraryService, mediaRef]
   );
 
   // Arrow keys step one frame while the slider is focused. Scoped to the slider
@@ -224,38 +294,25 @@ export default function VideoControls() {
     const rect = progressBarRef.current.getBoundingClientRect();
     const offsetX = latestMouseXRef.current - rect.left;
 
-    // Fractional seek target — NOT rounded to whole seconds. The previous
-    // Math.round + 0.05 gate is exactly what limited scrubbing to one-second
-    // steps. rAF already throttles sends to ~display rate.
+    // Fractional seek target — NOT rounded to whole seconds.
     const newTimeStamp = pixelToTime(offsetX, progressBarWidth, videoLength);
 
-    // Suppress only truly redundant sends (sub-millisecond), so single-frame
-    // drag movements still go through.
-    if (Math.abs(newTimeStamp - actualVideoTime) > 0.001) {
-      libraryService.send('SET_VIDEO_TIME', {
-        timeStamp: newTimeStamp,
-        eventId: uniqueId(), // Consider if uniqueId is needed here
-      });
-      // Don't update loop during drag for performance, maybe only on mouseup?
-      // If live loop update is needed, uncomment below, but test performance.
-      /*
-            if (loopLength > 0) {
-              libraryService.send('LOOP_VIDEO', {
-                loopStartTime: newTimeStamp,
-                loopLength,
-              });
-            }
-            */
+    // 1) Optimistic, cursor-locked visual feedback — no seek round-trip.
+    setDragTime(newTimeStamp);
+
+    // 2) Move the picture. Prefer a direct, coalesced element seek (fast, no
+    //    app-wide re-render). Only when no element ref is available do we fall
+    //    back to the XState path (which is what makes scrubbing feel laggy).
+    if (!seekElement(newTimeStamp)) {
+      if (Math.abs(newTimeStamp - actualVideoTimeRef.current) > 0.001) {
+        libraryService.send('SET_VIDEO_TIME', {
+          timeStamp: newTimeStamp,
+          eventId: uniqueId(),
+        });
+      }
     }
     rafRef.current = null; // Clear the raf ID after execution
-  }, [
-    progressBarRef,
-    progressBarWidth,
-    videoLength,
-    libraryService,
-    actualVideoTime,
-    // loopLength // Add if uncommenting loop update
-  ]);
+  }, [progressBarRef, progressBarWidth, videoLength, seekElement, libraryService]);
 
   // Function called by the mousemove listener to request an update frame
   const requestUpdateFrame = useCallback(() => {
@@ -274,14 +331,24 @@ export default function VideoControls() {
 
       wasPlayingRef.current = playing; // Store current playing state
       if (playing) {
-        // Pause the video only if it was playing
+        // Pause immediately (element + machine). The direct pause avoids the
+        // video advancing during the first drag frames while the XState round
+        // trip propagates.
+        mediaRef?.current?.pause();
         libraryService.send('SET_PLAYING_STATE', { playing: false });
       }
       setIsDragging(true);
       latestMouseXRef.current = e.clientX; // Store initial position
       performTimeUpdate(); // Perform initial update immediately on click
     },
-    [playing, libraryService, performTimeUpdate, progressBarWidth, videoLength] // Add deps
+    [
+      playing,
+      libraryService,
+      performTimeUpdate,
+      progressBarWidth,
+      videoLength,
+      mediaRef,
+    ]
   );
 
   // Effect to handle global mouse move and up listeners
@@ -300,34 +367,45 @@ export default function VideoControls() {
         rafRef.current = null;
       }
 
-      setIsDragging(false);
+      // Final precise position from the release point.
+      let finalTime = actualVideoTimeRef.current;
+      if (progressBarRef.current && progressBarWidth > 0 && videoLength > 0) {
+        const rect = progressBarRef.current.getBoundingClientRect();
+        const offsetX = e.clientX - rect.left;
+        finalTime = pixelToTime(offsetX, progressBarWidth, videoLength);
+      }
 
-      // Update one last time on mouseUp to ensure final position is set
-      // Use performTimeUpdate directly to ensure it runs
-      latestMouseXRef.current = e.clientX;
-      performTimeUpdate();
+      // Land the element exactly on the release point (covers the case where
+      // the last drag frame was coalesced away while a seek was in flight).
+      const el = mediaRef?.current;
+      if (el) el.currentTime = finalTime;
+
+      // Sync the machine AND actualVideoTime (which the thumb falls back to)
+      // before clearing the optimistic dragTime, so the bar doesn't flash back
+      // to a stale position on release. SET_ACTUAL_VIDEO_TIME also keeps the
+      // transcript / cue / tag-drop consumers in step.
+      libraryService.send('SET_VIDEO_TIME', {
+        timeStamp: finalTime,
+        eventId: uniqueId(),
+      });
+      libraryService.send('SET_ACTUAL_VIDEO_TIME', {
+        timeStamp: finalTime,
+        eventId: uniqueId(),
+      });
+
+      pendingSeekRef.current = null;
+      setIsDragging(false);
+      setDragTime(null);
 
       // Resume playing only if it was playing before dragging started
       if (wasPlayingRef.current) {
         libraryService.send('SET_PLAYING_STATE', { playing: true });
       }
 
-      // Optional: Set final loop position on mouseUp if not done during drag
-      if (
-        loopLength > 0 &&
-        progressBarRef.current &&
-        progressBarWidth > 0 &&
-        videoLength > 0
-      ) {
-        const rect = progressBarRef.current.getBoundingClientRect();
-        const offsetX = e.clientX - rect.left;
-        const finalTimeStamp = pixelToTime(
-          offsetX,
-          progressBarWidth,
-          videoLength
-        );
+      // Set final loop position on mouseUp (not updated live during drag).
+      if (loopLength > 0 && videoLength > 0) {
         libraryService.send('LOOP_VIDEO', {
-          loopStartTime: finalTimeStamp,
+          loopStartTime: finalTime,
           loopLength,
         });
       }
@@ -359,12 +437,12 @@ export default function VideoControls() {
     isDragging,
     requestUpdateFrame,
     libraryService,
-    performTimeUpdate,
+    mediaRef,
     loopLength,
     progressBarRef,
     progressBarWidth,
     videoLength,
-  ]); // Add performTimeUpdate and others to deps
+  ]);
 
   // --- Render (mostly same as before) ---
   return (
@@ -416,8 +494,8 @@ export default function VideoControls() {
             aria-label="Video progress"
             aria-valuemin={0}
             aria-valuemax={videoLength || 0}
-            aria-valuenow={actualVideoTime || 0}
-            aria-valuetext={getLabel(actualVideoTime || 0)}
+            aria-valuenow={displayTime || 0}
+            aria-valuetext={getLabel(displayTime || 0)}
             tabIndex={0} // Make focusable
             onKeyDown={handleSliderKeyDown}
             onMouseMove={handleProgressHover}
@@ -440,7 +518,7 @@ export default function VideoControls() {
                 width:
                   progressBarWidth > 0 && videoLength > 0
                     ? `${mapRange(
-                        actualVideoTime,
+                        displayTime,
                         0,
                         videoLength,
                         0,
@@ -457,7 +535,7 @@ export default function VideoControls() {
                 left:
                   progressBarWidth > 0 && videoLength > 0
                     ? `${mapRange(
-                        actualVideoTime,
+                        displayTime,
                         0,
                         videoLength,
                         0,
@@ -470,7 +548,7 @@ export default function VideoControls() {
             ></div>
           </div>
           <div className="timestamp-label">
-            <span className="value">{getLabel(actualVideoTime)}</span>
+            <span className="value">{getLabel(displayTime)}</span>
             <span className="total value"> / {getLabel(videoLength)}</span>
           </div>
         </div>

--- a/src/renderer/components/detail/detail.tsx
+++ b/src/renderer/components/detail/detail.tsx
@@ -214,7 +214,14 @@ export function Detail({ offset = 0 }: { offset?: number }) {
         container.removeEventListener('wheel', handleScroll);
       }
     };
-  }, [containerRef.current, settings.controlMode]);
+    // Key on `item?.path` (not `containerRef.current`): the container is only
+    // rendered once `item` is truthy (see the `if (!item) return null` early
+    // return), and ref assignment doesn't trigger a re-render. Depending on the
+    // ref meant the effect ran once while the ref was still null (on the initial
+    // mount before the library loaded) and never re-ran when the container
+    // mounted — so the wheel listener never attached until an unrelated re-render
+    // (e.g. toggling controlMode) happened to re-run it.
+  }, [item?.path, settings.controlMode]);
 
   function handleClick(e: React.MouseEvent<HTMLDivElement, MouseEvent>) {
     const rect = containerRef.current!.getBoundingClientRect();
@@ -375,7 +382,9 @@ export function Detail({ offset = 0 }: { offset?: number }) {
         (getFileType(item.path) === 'video' ||
           getFileType(item.path) === 'audio') && (
           <div className="videoControls">
-            <VideoControls />
+            <VideoControls
+              mediaRef={mediaRef as React.RefObject<HTMLMediaElement>}
+            />
           </div>
         )}
       {settings.showTags === 'all' || settings.showTags === 'detail' ? (

--- a/src/renderer/components/icons/tag-plus-icon.tsx
+++ b/src/renderer/components/icons/tag-plus-icon.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+// A tag with a "+" badge — used to apply a tag to the current media item
+// (as opposed to adding it to the search query).
+export default function TagPlusIcon(
+  props: React.SVGProps<SVGSVGElement>
+): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="14"
+      height="14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      {/* Tag body (lower-left) */}
+      <path d="M2 10 10 2h4a2 2 0 0 1 2 2v4l-8 8a2 2 0 0 1-2.83 0L2 12.83A2 2 0 0 1 2 10z" />
+      {/* Tag hole */}
+      <circle cx="6.4" cy="6.4" r="1.1" fill="currentColor" stroke="none" />
+      {/* Plus badge (upper-right) */}
+      <path d="M19 13v6M16 16h6" />
+    </svg>
+  );
+}

--- a/src/renderer/components/layout/layout.tsx
+++ b/src/renderer/components/layout/layout.tsx
@@ -170,6 +170,18 @@ const Layout = () => {
     }
   }
 
+  // Collapse only the list panel — leave detail and metadata as-is. Used when
+  // navigating to a single file: the list isn't useful with one item, but the
+  // metadata panel (and its path tree, used to navigate) must stay open.
+  function collapseList() {
+    setRenderID((id) => id + 1);
+    try {
+      listRef.current?.resize('0%');
+    } catch {
+      // Panels not yet registered, ignore
+    }
+  }
+
   function handleDetailClick() {
     try {
       if (listRef.current?.isCollapsed()) {
@@ -188,9 +200,11 @@ const Layout = () => {
 
   useEffect(() => {
     if (library.length === 1) {
-      // Delay to ensure panels are registered
+      // Collapse the list to focus the single file. Only the list collapses;
+      // the metadata panel stays open so its path tree remains usable for
+      // navigation (and doesn't flash-and-vanish on each click).
       const timer = setTimeout(() => {
-        handleListClick();
+        collapseList();
       }, 0);
       return () => clearTimeout(timer);
     }

--- a/src/renderer/components/layout/panels.tsx
+++ b/src/renderer/components/layout/panels.tsx
@@ -2,10 +2,14 @@ import React, { useContext } from 'react';
 import { GlobalStateContext } from '../../state';
 import Layout from './layout';
 import useFileDrop from '../../hooks/useFileDrop';
+import { useWarmTagSearch } from '../../hooks/useWarmTagSearch';
 
 export function Panels() {
   const { libraryService } = useContext(GlobalStateContext);
   const { dropRef, isOver, canDrop } = useFileDrop();
+  // Build the shared tag-search index at startup so the first type-ahead from
+  // the taxonomy sidebar or command palette is instant.
+  useWarmTagSearch();
 
   return (
     <>

--- a/src/renderer/components/media-viewers/video.tsx
+++ b/src/renderer/components/media-viewers/video.tsx
@@ -9,6 +9,7 @@ import Hls from 'hls.js';
 import { mediaUrl, hlsUrl, fetchMediaPreview as platformFetchMediaPreview, findSubtitle } from '../../platform';
 import { toVttString, vttBlobUrl } from './subtitle-loader';
 import { useVisibilityLoader } from '../../hooks/useVisibilityLoader';
+import { estimateFrameRate } from '../../video-frame';
 
 import './video.css';
 import './sizing.css';
@@ -197,6 +198,56 @@ export function Video({
       video.removeEventListener('timeupdate', handleTimeUpdate);
     };
   }, [onTimestampChange]);
+
+  // Detect the video's frame rate from requestVideoFrameCallback cadence so the
+  // controls can step a single frame. Runs only for the controlling (settable)
+  // player. Resets to 0 (unknown) on path change, then dispatches once a stable
+  // estimate emerges. If rVFC is unavailable or no stable estimate is reached,
+  // frameRate stays 0 and the controls fall back to a 30fps step.
+  useEffect(() => {
+    const video = mediaRef?.current;
+    if (!video || !settable) return;
+
+    // Clear any stale frame rate carried over from the previous clip.
+    libraryService.send('SET_VIDEO_FRAME_RATE', { frameRate: 0 });
+
+    const rvfc = (video as any).requestVideoFrameCallback?.bind(video) as
+      | ((cb: (now: number, metadata: any) => void) => number)
+      | undefined;
+    const cancelRvfc = (video as any).cancelVideoFrameCallback?.bind(video) as
+      | ((handle: number) => void)
+      | undefined;
+    if (!rvfc) return; // Unsupported — leave frameRate 0.
+
+    const samples: number[] = [];
+    let handle: number | null = null;
+    let done = false;
+
+    const onFrame = (_now: number, metadata: any) => {
+      if (done) return;
+      if (typeof metadata?.mediaTime === 'number') {
+        samples.push(metadata.mediaTime);
+      }
+      if (samples.length >= 8) {
+        const fps = estimateFrameRate(samples);
+        if (fps > 0) {
+          libraryService.send('SET_VIDEO_FRAME_RATE', { frameRate: fps });
+          done = true;
+          return;
+        }
+        // Heavy looping/seeking produced only unusable deltas — keep a recent
+        // window and keep sampling rather than growing unbounded.
+        if (samples.length > 64) samples.splice(0, samples.length - 8);
+      }
+      handle = rvfc(onFrame);
+    };
+    handle = rvfc(onFrame);
+
+    return () => {
+      done = true;
+      if (handle != null && cancelRvfc) cancelRvfc(handle);
+    };
+  }, [path, settable, libraryService]);
 
   useEffect(() => {
     const video = mediaRef?.current;

--- a/src/renderer/components/media-viewers/video.tsx
+++ b/src/renderer/components/media-viewers/video.tsx
@@ -78,10 +78,8 @@ export function Video({
   useHLS = false,
 }: Props) {
   const { libraryService } = useContext(GlobalStateContext);
-  const { timeStamp, loopLength, loopStartTime, playing } = useSelector(
-    libraryService,
-    (state) => state.context.videoPlayer
-  );
+  const { timeStamp, loopLength, loopStartTime, playing, playbackRate } =
+    useSelector(libraryService, (state) => state.context.videoPlayer);
 
   const eventId = useSelector(
     libraryService,
@@ -358,6 +356,14 @@ export function Video({
       mediaRef.current.volume = clampVolume(volume);
     }
   }, [volume]);
+
+  // Apply the playback-speed setting. Keyed on `path` too so it re-applies when
+  // a new clip mounts (a fresh element defaults back to 1x).
+  useEffect(() => {
+    if (mediaRef && mediaRef.current && settable) {
+      mediaRef.current.playbackRate = playbackRate;
+    }
+  }, [playbackRate, settable, path]);
 
   const hlsRef = useRef<Hls | null>(null);
   const [hlsFailed, setHlsFailed] = useState(false);

--- a/src/renderer/components/metadata/customPromptStore.ts
+++ b/src/renderer/components/metadata/customPromptStore.ts
@@ -19,6 +19,13 @@ export function setLastCustomPrompt(value: string): void {
   lastCustomPrompt = value;
 }
 
+// Explicitly forget the remembered prompt so the next generate falls back to
+// the configured default. Distinct from `setLastCustomPrompt('')`, which is a
+// deliberate no-op — this is the user asking to reset, not an empty submission.
+export function clearLastCustomPrompt(): void {
+  lastCustomPrompt = '';
+}
+
 export function getCachedDefaultPrompt(): string | null {
   return cachedDefaultPrompt;
 }

--- a/src/renderer/components/metadata/file-metadata.tsx
+++ b/src/renderer/components/metadata/file-metadata.tsx
@@ -8,6 +8,7 @@ import Tags from './tags';
 import PathTree from './path-tree';
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
 import { Description } from './description';
+import PathActions from './path-actions';
 import { useContext } from 'react';
 import { GlobalStateContext } from '../../state';
 
@@ -36,6 +37,7 @@ export default function FileMetadata({ item }: { item: any }) {
       <div className="FileMetadata">
         <div className="section">
           <h2>Path</h2>
+          {item?.path && <PathActions path={item.path} />}
           {item?.path && <PathTree path={item?.path} />}
         </div>
         <div className="section">
@@ -60,6 +62,7 @@ export default function FileMetadata({ item }: { item: any }) {
     <div className="FileMetadata">
       <div className="section">
         <h2>Path</h2>
+        {item?.path && <PathActions path={item.path} />}
         {item?.path && <PathTree path={item?.path} />}
       </div>
       <div

--- a/src/renderer/components/metadata/file-metadata.tsx
+++ b/src/renderer/components/metadata/file-metadata.tsx
@@ -69,8 +69,8 @@ export default function FileMetadata({ item }: { item: any }) {
         className="section action"
         onClick={() => {
           libraryService.send({
-            type: 'SET_TEXT_FILTER',
-            data: { textFilter: `hash:${data.hash}` },
+            type: 'SET_QUERY',
+            data: { text: `hash:${data.hash}` },
           });
         }}
       >

--- a/src/renderer/components/metadata/generate-description.css
+++ b/src/renderer/components/metadata/generate-description.css
@@ -175,8 +175,33 @@
   font-style: italic;
 }
 
+.GenerateDescription .prompt-footer {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .GenerateDescription .prompt-hint {
   font-size: 10px;
   color: #777;
   line-height: 1.3;
+}
+
+.GenerateDescription .prompt-reset {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 10px;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.GenerateDescription .prompt-reset:hover {
+  background: none;
+  border: none;
+  color: #ccc;
 }

--- a/src/renderer/components/metadata/generate-description.tsx
+++ b/src/renderer/components/metadata/generate-description.tsx
@@ -7,6 +7,7 @@ import {
   setCachedDefaultPrompt,
   getLastCustomPrompt,
   setLastCustomPrompt,
+  clearLastCustomPrompt,
 } from './customPromptStore';
 import { SparkleIcon, TuneIcon } from './section-action-icons';
 
@@ -153,6 +154,16 @@ export default function GenerateDescription({
     }
   };
 
+  // Forget the remembered override so this and future generates use the
+  // configured default again. Clears both the live draft and the session store
+  // so the reset survives the panel/component remounting.
+  const handleResetPrompt = () => {
+    setPromptDraft('');
+    clearLastCustomPrompt();
+  };
+
+  const hasCustomPrompt = promptDraft.trim() !== '';
+
   const isCorner = variant === 'corner';
 
   // In the corner-pill context we stay quiet until the job service is
@@ -202,9 +213,21 @@ export default function GenerateDescription({
         onKeyUp={(e) => e.stopPropagation()}
         rows={4}
       />
-      <div className="prompt-hint">
-        Leave empty to use the configured default. This prompt is remembered for
-        the rest of your session — your global config is unchanged.
+      <div className="prompt-footer">
+        <div className="prompt-hint">
+          Leave empty to use the configured default. This prompt is remembered
+          for the rest of your session — your global config is unchanged.
+        </div>
+        {hasCustomPrompt && (
+          <button
+            type="button"
+            className="prompt-reset"
+            onClick={handleResetPrompt}
+            title="Clear the custom prompt and use the configured default"
+          >
+            Reset to default
+          </button>
+        )}
       </div>
     </div>
   ) : null;

--- a/src/renderer/components/metadata/path-actions.css
+++ b/src/renderer/components/metadata/path-actions.css
@@ -1,0 +1,68 @@
+/* Action buttons for the Path section, pinned to the section's top-right
+   corner (the title chip lives top-left). No background — just the icons. */
+.path-actions {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  padding: 0.3rem 0.4rem;
+}
+
+.path-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  margin: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  opacity: 0.6;
+  line-height: 0;
+}
+
+.path-action:hover {
+  opacity: 1;
+}
+
+.path-action .path-action-icon {
+  display: block;
+  width: 13px;
+  height: 13px;
+}
+
+/* Copy success: pop the button. */
+.path-action.copied {
+  animation: path-action-pop 0.35s ease;
+}
+
+@keyframes path-action-pop {
+  0% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.35);
+  }
+  70% {
+    transform: scale(0.92);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+/* Copy success: draw the checkmark in. */
+.path-action .path-action-icon.check path {
+  stroke-dasharray: 24;
+  stroke-dashoffset: 24;
+  animation: path-action-check-draw 0.4s ease forwards;
+}
+
+@keyframes path-action-check-draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}

--- a/src/renderer/components/metadata/path-actions.tsx
+++ b/src/renderer/components/metadata/path-actions.tsx
@@ -1,0 +1,101 @@
+import { FC, useEffect, useRef, useState } from 'react';
+import copyIcon from '../../../../assets/copy.svg';
+import { isElectron, send } from '../../platform';
+import './path-actions.css';
+
+interface PathActionsProps {
+  path: string;
+}
+
+const COPIED_RESET_MS = 1200;
+
+const PathActions: FC<PathActionsProps> = ({ path }) => {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    },
+    []
+  );
+
+  const handleCopy = async (e: React.MouseEvent) => {
+    // The Path heading sits in a section; don't let clicks bubble up.
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(path);
+      setCopied(true);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => setCopied(false), COPIED_RESET_MS);
+    } catch (err) {
+      console.error('Failed to copy path: ', err);
+    }
+  };
+
+  const handleReveal = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    send('show-item-in-folder', [path]);
+  };
+
+  return (
+    <div className="path-actions">
+      {isElectron && (
+        <button
+          type="button"
+          className="path-action"
+          onClick={handleReveal}
+          title="Show in file explorer"
+          aria-label="Show in file explorer"
+        >
+          <svg
+            className="path-action-icon"
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3 7a2 2 0 0 1 2-2h3.5l2 2H19a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"
+              stroke="#ffffff"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      )}
+      <button
+        type="button"
+        className={`path-action${copied ? ' copied' : ''}`}
+        onClick={handleCopy}
+        title="Copy file path"
+        aria-label="Copy file path"
+      >
+        {copied ? (
+          <svg
+            className="path-action-icon check"
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5 13l4 4L19 7"
+              stroke="#ffffff"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        ) : (
+          <img className="path-action-icon" src={copyIcon} alt="" />
+        )}
+      </button>
+    </div>
+  );
+};
+
+export default PathActions;

--- a/src/renderer/components/query-input/QueryInput.tsx
+++ b/src/renderer/components/query-input/QueryInput.tsx
@@ -2,7 +2,11 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { useSearchHistory } from '../../hooks/useSearchHistory';
 import type { Query, Predicate } from '../../query/types';
 import { predicateKey } from '../../query/types';
+import type { FilterModeOption } from '../../../settings';
 import clear from '../../../../assets/cancel.svg';
+import union from '../../../../assets/union.svg';
+import intersect from '../../../../assets/intersect.svg';
+import selective from '../../../../assets/selective.svg';
 import './query-input.css';
 
 interface QueryInputProps {
@@ -27,6 +31,13 @@ interface QueryInputProps {
   resultNavCount?: number;
   onResultNavMove?: (delta: 1 | -1) => void;
   onResultNavSubmit?: () => void;
+  // Tag-filtering behaviour toggle. When both are supplied, an icon button is
+  // rendered in the input that cycles Intersection → Union → Exclusive (the
+  // same `filteringMode` setting the taxonomy sidebar toggles). Omitted →
+  // the toggle is not rendered, so callers that don't drive the setting are
+  // unaffected.
+  filteringMode?: FilterModeOption;
+  onCycleFilterMode?: () => void;
 }
 
 const CHEAT_SHEET = [
@@ -48,6 +59,21 @@ const TYPE_GLYPH: Record<Predicate['type'], string> = {
   hash: 'hash:',
 };
 
+// Icons + labels for the three tag-filtering behaviours, mirroring the toggle
+// in the taxonomy sidebar (taxonomy.tsx). The same `filteringMode` setting
+// drives both, so the icon shown here always matches the sidebar toggle.
+const FILTER_MODE_ICONS: Record<FilterModeOption, string> = {
+  OR: union,
+  AND: intersect,
+  EXCLUSIVE: selective,
+};
+
+const FILTER_MODE_LABELS: Record<FilterModeOption, string> = {
+  OR: 'Union',
+  AND: 'Intersection',
+  EXCLUSIVE: 'Exclusive',
+};
+
 const MAX_VISIBLE_RECENT = 5;
 const MAX_VISIBLE_FILTERED = 10;
 
@@ -67,6 +93,8 @@ export default function QueryInput({
   resultNavCount = 0,
   onResultNavMove,
   onResultNavSubmit,
+  filteringMode,
+  onCycleFilterMode,
 }: QueryInputProps) {
   const { history, addSearch, removeSearch, clearAll } = useSearchHistory();
   // The parent owns a navigable results list (command palette). While it has
@@ -358,6 +386,19 @@ export default function QueryInput({
           onBlur={handleBlur}
           disabled={disabled}
         />
+        {filteringMode && onCycleFilterMode && (
+          <button
+            className="query-input-filter-mode"
+            title={`Tag filtering: ${FILTER_MODE_LABELS[filteringMode]} (click to cycle Intersection / Union / Exclusive)`}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={onCycleFilterMode}
+          >
+            <img
+              src={FILTER_MODE_ICONS[filteringMode]}
+              alt={FILTER_MODE_LABELS[filteringMode]}
+            />
+          </button>
+        )}
         <button
           className="query-input-help"
           title="Query syntax help"

--- a/src/renderer/components/query-input/QueryInput.tsx
+++ b/src/renderer/components/query-input/QueryInput.tsx
@@ -12,6 +12,7 @@ interface QueryInputProps {
   onSubmitText: () => void; // Enter pressed with text present (taxonomy decides what to commit)
   onRemovePredicate: (key: string) => void;
   onToggleExclude: (key: string) => void;
+  onSetPredicateJoin: (key: string, join: 'AND' | 'OR') => void;
   onClearAll: () => void; // clear chips + text
   onFocus?: () => void;
   disabled?: boolean;
@@ -46,6 +47,7 @@ export default function QueryInput({
   onSubmitText,
   onRemovePredicate,
   onToggleExclude,
+  onSetPredicateJoin,
   onClearAll,
   onFocus,
   disabled = false,
@@ -214,6 +216,7 @@ export default function QueryInput({
         <div className="query-chips">
           {query.predicates.map((p) => {
             const key = predicateKey(p);
+            const join = p.join ?? 'AND';
             const chipClass = `query-chip${p.exclude ? ' exclude' : ''}${
               p.type === 'category' ? ' category' : ''
             }`;
@@ -226,6 +229,19 @@ export default function QueryInput({
                   p.exclude ? 'Click to include' : 'Click to exclude'
                 }
               >
+                <button
+                  type="button"
+                  className={`query-chip-join${
+                    join === 'OR' ? ' query-chip-join--or' : ''
+                  }`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSetPredicateJoin(key, join === 'AND' ? 'OR' : 'AND');
+                  }}
+                  title="Toggle AND/OR"
+                >
+                  {join}
+                </button>
                 <span className="query-chip-label">
                   {p.exclude ? '−' : ''}
                   {TYPE_GLYPH[p.type]}

--- a/src/renderer/components/query-input/QueryInput.tsx
+++ b/src/renderer/components/query-input/QueryInput.tsx
@@ -1,33 +1,53 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useSearchHistory } from '../../hooks/useSearchHistory';
+import type { Query, Predicate } from '../../query/types';
+import { predicateKey } from '../../query/types';
 import clear from '../../../../assets/cancel.svg';
 import './query-input.css';
 
 interface QueryInputProps {
-  value: string;
-  onChange: (value: string) => void;
-  onSubmit: (value: string) => void;
-  onClear: () => void;
+  query: Query;
+  textValue: string;
+  onTextChange: (value: string) => void;
+  onSubmitText: () => void; // Enter pressed with text present (taxonomy decides what to commit)
+  onRemovePredicate: (key: string) => void;
+  onToggleExclude: (key: string) => void;
+  onClearAll: () => void; // clear chips + text
+  onFocus?: () => void;
   disabled?: boolean;
 }
 
 const CHEAT_SHEET = [
   { syntax: '"quoted phrase"', desc: 'Exact match' },
   { syntax: 'tag:name', desc: 'Search tags' },
+  { syntax: 'in:category', desc: 'Filter by category' },
   { syntax: 'path:dir', desc: 'Search paths' },
   { syntax: 'description:txt', desc: 'Search descriptions' },
   { syntax: 'hash:abc', desc: 'Search by hash' },
   { syntax: '-term', desc: 'Exclude term' },
 ];
 
+// Glyph prefix shown on a chip for each predicate type.
+const TYPE_GLYPH: Record<Predicate['type'], string> = {
+  tag: '#',
+  category: 'in:',
+  path: 'path:',
+  description: 'description:',
+  hash: 'hash:',
+};
+
 const MAX_VISIBLE_RECENT = 5;
 const MAX_VISIBLE_FILTERED = 10;
 
 export default function QueryInput({
-  value,
-  onChange,
-  onSubmit,
-  onClear,
+  query,
+  textValue,
+  onTextChange,
+  onSubmitText,
+  onRemovePredicate,
+  onToggleExclude,
+  onClearAll,
+  onFocus,
   disabled = false,
 }: QueryInputProps) {
   const { history, addSearch, removeSearch, clearAll } = useSearchHistory();
@@ -38,10 +58,10 @@ export default function QueryInput({
   const containerRef = useRef<HTMLDivElement>(null);
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const filteredHistory = value.trim()
+  const filteredHistory = textValue.trim()
     ? history
         .filter((item) =>
-          item.toLowerCase().includes(value.trim().toLowerCase())
+          item.toLowerCase().includes(textValue.trim().toLowerCase())
         )
         .slice(0, MAX_VISIBLE_FILTERED)
     : history.slice(0, MAX_VISIBLE_RECENT);
@@ -51,7 +71,7 @@ export default function QueryInput({
   // Reset highlight when input changes
   useEffect(() => {
     setHighlightIndex(-1);
-  }, [value]);
+  }, [textValue]);
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -74,7 +94,8 @@ export default function QueryInput({
       blurTimeoutRef.current = null;
     }
     setIsOpen(true);
-  }, []);
+    onFocus?.();
+  }, [onFocus]);
 
   const handleBlur = useCallback(() => {
     blurTimeoutRef.current = setTimeout(() => {
@@ -83,28 +104,30 @@ export default function QueryInput({
     }, 200);
   }, []);
 
+  // Select a search-history entry: push its text into the input, record it,
+  // then commit it via the taxonomy-owned submit handler.
   const selectItem = useCallback(
-    (query: string) => {
-      onChange(query);
-      addSearch(query);
-      onSubmit(query);
+    (item: string) => {
+      onTextChange(item);
+      addSearch(item);
+      onSubmitText();
       setIsOpen(false);
       setShowCheatSheet(false);
       setHighlightIndex(-1);
     },
-    [onChange, addSearch, onSubmit]
+    [onTextChange, addSearch, onSubmitText]
   );
 
   const handleSubmit = useCallback(() => {
-    const trimmed = value.trim();
+    const trimmed = textValue.trim();
     if (trimmed) {
       addSearch(trimmed);
-      onSubmit(trimmed);
+      onSubmitText();
       setIsOpen(false);
       setShowCheatSheet(false);
       setHighlightIndex(-1);
     }
-  }, [value, addSearch, onSubmit]);
+  }, [textValue, addSearch, onSubmitText]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -151,7 +174,7 @@ export default function QueryInput({
         case 'Delete':
         case 'Backspace':
           if (
-            !value &&
+            !textValue &&
             highlightIndex >= 0 &&
             highlightIndex < filteredHistory.length
           ) {
@@ -171,7 +194,7 @@ export default function QueryInput({
       showCheatSheet,
       highlightIndex,
       filteredHistory,
-      value,
+      textValue,
       handleSubmit,
       selectItem,
       removeSearch,
@@ -179,22 +202,57 @@ export default function QueryInput({
   );
 
   const handleClear = useCallback(() => {
-    onChange('');
-    onClear();
+    onClearAll();
     setHighlightIndex(-1);
-  }, [onChange, onClear]);
+  }, [onClearAll]);
 
   const dropdownOpen = isOpen && hasItems;
 
   return (
     <div className="query-input" ref={containerRef}>
+      {query.predicates.length > 0 && (
+        <div className="query-chips">
+          {query.predicates.map((p) => {
+            const key = predicateKey(p);
+            const chipClass = `query-chip${p.exclude ? ' exclude' : ''}${
+              p.type === 'category' ? ' category' : ''
+            }`;
+            return (
+              <span
+                className={chipClass}
+                key={key}
+                onClick={() => onToggleExclude(key)}
+                title={
+                  p.exclude ? 'Click to include' : 'Click to exclude'
+                }
+              >
+                <span className="query-chip-label">
+                  {p.exclude ? '−' : ''}
+                  {TYPE_GLYPH[p.type]}
+                  {p.value}
+                </span>
+                <button
+                  className="query-chip-remove"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRemovePredicate(key);
+                  }}
+                  title="Remove"
+                >
+                  &times;
+                </button>
+              </span>
+            );
+          })}
+        </div>
+      )}
       <div className="query-input-field">
         <input
           ref={inputRef}
           type="text"
-          placeholder="Search Content"
-          value={value}
-          onChange={(e) => onChange(e.currentTarget.value)}
+          placeholder="Search & filter"
+          value={textValue}
+          onChange={(e) => onTextChange(e.currentTarget.value)}
           onKeyDown={handleKeyDown}
           onKeyUp={(e) => e.stopPropagation()}
           onFocus={handleFocus}
@@ -216,7 +274,7 @@ export default function QueryInput({
         <button
           className="query-input-submit"
           onClick={handleSubmit}
-          disabled={!value.trim() || disabled}
+          disabled={!textValue.trim() || disabled}
           title="Search"
         >
           &rarr;
@@ -244,7 +302,9 @@ export default function QueryInput({
           ) : (
             <div className="query-input-history">
               <div className="query-input-section-header">
-                <span>{value.trim() ? 'Search History' : 'Recent Searches'}</span>
+                <span>
+                  {textValue.trim() ? 'Search History' : 'Recent Searches'}
+                </span>
                 {history.length > 0 && (
                   <button
                     className="query-input-clear-all"

--- a/src/renderer/components/query-input/QueryInput.tsx
+++ b/src/renderer/components/query-input/QueryInput.tsx
@@ -13,7 +13,8 @@ interface QueryInputProps {
   onRemovePredicate: (key: string) => void;
   onToggleExclude: (key: string) => void;
   onSetPredicateJoin: (key: string, join: 'AND' | 'OR') => void;
-  onClearAll: () => void; // clear chips + text
+  onClearAll: () => void; // clear chips + text (resets the library)
+  onClearText: () => void; // clear only the typed text (no-op on the library)
   onFocus?: () => void;
   autoFocus?: boolean; // focus the text input on mount (fast palette workflow)
   disabled?: boolean;
@@ -50,6 +51,7 @@ export default function QueryInput({
   onToggleExclude,
   onSetPredicateJoin,
   onClearAll,
+  onClearText,
   onFocus,
   autoFocus = false,
   disabled = false,
@@ -213,9 +215,16 @@ export default function QueryInput({
   );
 
   const handleClear = useCallback(() => {
-    onClearAll();
+    // Clearing filters resets the library to its pre-filter state. Clearing
+    // only typed text must NOT touch the library — so when there are no
+    // predicates, clear the text alone.
+    if (query.predicates.length > 0) {
+      onClearAll();
+    } else {
+      onClearText();
+    }
     setHighlightIndex(-1);
-  }, [onClearAll]);
+  }, [query.predicates.length, onClearAll, onClearText]);
 
   const dropdownOpen = isOpen && hasItems;
 

--- a/src/renderer/components/query-input/QueryInput.tsx
+++ b/src/renderer/components/query-input/QueryInput.tsx
@@ -214,7 +214,7 @@ export default function QueryInput({
     <div className="query-input" ref={containerRef}>
       {query.predicates.length > 0 && (
         <div className="query-chips">
-          {query.predicates.map((p) => {
+          {query.predicates.map((p, index) => {
             const key = predicateKey(p);
             const join = p.join ?? 'AND';
             const chipClass = `query-chip${p.exclude ? ' exclude' : ''}${
@@ -229,19 +229,21 @@ export default function QueryInput({
                   p.exclude ? 'Click to include' : 'Click to exclude'
                 }
               >
-                <button
-                  type="button"
-                  className={`query-chip-join${
-                    join === 'OR' ? ' query-chip-join--or' : ''
-                  }`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onSetPredicateJoin(key, join === 'AND' ? 'OR' : 'AND');
-                  }}
-                  title="Toggle AND/OR"
-                >
-                  {join}
-                </button>
+                {index > 0 && (
+                  <button
+                    type="button"
+                    className={`query-chip-join${
+                      join === 'OR' ? ' query-chip-join--or' : ''
+                    }`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSetPredicateJoin(key, join === 'AND' ? 'OR' : 'AND');
+                    }}
+                    title="Toggle AND/OR"
+                  >
+                    {join}
+                  </button>
+                )}
                 <span className="query-chip-label">
                   {p.exclude ? '−' : ''}
                   {TYPE_GLYPH[p.type]}

--- a/src/renderer/components/query-input/QueryInput.tsx
+++ b/src/renderer/components/query-input/QueryInput.tsx
@@ -18,6 +18,15 @@ interface QueryInputProps {
   onFocus?: () => void;
   autoFocus?: boolean; // focus the text input on mount (fast palette workflow)
   disabled?: boolean;
+  // Result-navigation bridge. When the parent renders its own results surface
+  // (the command palette) and passes resultNavCount > 0, the input forwards
+  // Arrow Up/Down and Enter to the parent so the user can keyboard-navigate the
+  // highlighted result, and the internal history dropdown is suppressed (the
+  // results surface is what the user is navigating). Omitted everywhere else
+  // (e.g. the taxonomy sidebar), which keeps the original history behaviour.
+  resultNavCount?: number;
+  onResultNavMove?: (delta: 1 | -1) => void;
+  onResultNavSubmit?: () => void;
 }
 
 const CHEAT_SHEET = [
@@ -55,8 +64,14 @@ export default function QueryInput({
   onFocus,
   autoFocus = false,
   disabled = false,
+  resultNavCount = 0,
+  onResultNavMove,
+  onResultNavSubmit,
 }: QueryInputProps) {
   const { history, addSearch, removeSearch, clearAll } = useSearchHistory();
+  // The parent owns a navigable results list (command palette). While it has
+  // items, arrow/enter drive that list instead of the history dropdown.
+  const resultNavActive = resultNavCount > 0;
   const [isOpen, setIsOpen] = useState(false);
   const [showCheatSheet, setShowCheatSheet] = useState(false);
   const [highlightIndex, setHighlightIndex] = useState(-1);
@@ -150,6 +165,27 @@ export default function QueryInput({
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       e.stopPropagation();
 
+      // Result-navigation mode: the parent's results surface owns the
+      // highlight, so arrow/enter drive it instead of the history dropdown.
+      if (resultNavActive) {
+        switch (e.key) {
+          case 'ArrowDown':
+            e.preventDefault();
+            onResultNavMove?.(1);
+            return;
+          case 'ArrowUp':
+            e.preventDefault();
+            onResultNavMove?.(-1);
+            return;
+          case 'Enter':
+            e.preventDefault();
+            onResultNavSubmit?.();
+            return;
+          default:
+            return; // typing and everything else: let the input handle it
+        }
+      }
+
       if (!isOpen || !hasItems || showCheatSheet) {
         if (e.key === 'Enter') {
           handleSubmit();
@@ -224,6 +260,9 @@ export default function QueryInput({
       handleSubmit,
       selectItem,
       removeSearch,
+      resultNavActive,
+      onResultNavMove,
+      onResultNavSubmit,
     ]
   );
 
@@ -239,7 +278,9 @@ export default function QueryInput({
     setHighlightIndex(-1);
   }, [query.predicates.length, onClearAll, onClearText]);
 
-  const dropdownOpen = isOpen && hasItems;
+  // Suppress the history dropdown while the parent's results surface is the
+  // active navigation target, so the two don't overlap or fight for arrow keys.
+  const dropdownOpen = !resultNavActive && isOpen && hasItems;
 
   return (
     <div className="query-input" ref={containerRef}>

--- a/src/renderer/components/query-input/QueryInput.tsx
+++ b/src/renderer/components/query-input/QueryInput.tsx
@@ -15,6 +15,7 @@ interface QueryInputProps {
   onSetPredicateJoin: (key: string, join: 'AND' | 'OR') => void;
   onClearAll: () => void; // clear chips + text
   onFocus?: () => void;
+  autoFocus?: boolean; // focus the text input on mount (fast palette workflow)
   disabled?: boolean;
 }
 
@@ -50,6 +51,7 @@ export default function QueryInput({
   onSetPredicateJoin,
   onClearAll,
   onFocus,
+  autoFocus = false,
   disabled = false,
 }: QueryInputProps) {
   const { history, addSearch, removeSearch, clearAll } = useSearchHistory();
@@ -59,6 +61,13 @@ export default function QueryInput({
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Focus the text input on mount when requested (e.g. the command palette
+  // opens) so the user can start typing a query immediately.
+  useEffect(() => {
+    if (autoFocus) inputRef.current?.focus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const filteredHistory = textValue.trim()
     ? history

--- a/src/renderer/components/query-input/QueryInput.tsx
+++ b/src/renderer/components/query-input/QueryInput.tsx
@@ -106,7 +106,11 @@ export default function QueryInput({
       clearTimeout(blurTimeoutRef.current);
       blurTimeoutRef.current = null;
     }
-    setIsOpen(true);
+    // Deliberately do NOT open the dropdown on focus. The command palette
+    // programmatically focuses this input on mount (autoFocus), and opening on
+    // focus made the history dropdown appear before the user interacted at all.
+    // The dropdown opens only on genuine intent: typing, an intentional
+    // mouse-down on the input, or ArrowDown (see below).
     onFocus?.();
   }, [onFocus]);
 
@@ -154,6 +158,15 @@ export default function QueryInput({
         if (e.key === 'Escape') {
           setIsOpen(false);
           setShowCheatSheet(false);
+          return;
+        }
+        // Keyboard affordance: open (and highlight the first row) on ArrowDown
+        // so keyboard-only users can still reach history now that focus alone
+        // no longer opens the dropdown.
+        if (e.key === 'ArrowDown' && hasItems && !showCheatSheet) {
+          e.preventDefault();
+          setIsOpen(true);
+          setHighlightIndex(0);
           return;
         }
         return;
@@ -288,7 +301,16 @@ export default function QueryInput({
           type="text"
           placeholder="Search & filter"
           value={textValue}
-          onChange={(e) => onTextChange(e.currentTarget.value)}
+          onChange={(e) => {
+            // Typing is intent — open the dropdown so matching history shows.
+            setIsOpen(true);
+            onTextChange(e.currentTarget.value);
+          }}
+          onMouseDown={() => {
+            // An intentional click into the input opens the dropdown (focus
+            // alone no longer does, to keep the palette's autoFocus quiet).
+            setIsOpen(true);
+          }}
           onKeyDown={handleKeyDown}
           onKeyUp={(e) => e.stopPropagation()}
           onFocus={handleFocus}

--- a/src/renderer/components/query-input/query-input.css
+++ b/src/renderer/components/query-input/query-input.css
@@ -10,6 +10,59 @@
   position: relative;
 }
 
+/* Chips (active unified query predicates) */
+.query-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  padding: 0.25rem 0.5rem 0;
+}
+
+.query-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin: 2px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 12px;
+  cursor: pointer;
+  background: #2b3a4a;
+  color: #cfe3f5;
+  border: 1px solid #3d5a78;
+}
+
+.query-chip.exclude {
+  background: #4a2b2b;
+  color: #f5cfcf;
+  border-color: #784040;
+}
+
+.query-chip.category {
+  background: #2b4a38;
+  color: #cff5dc;
+  border-color: #3d785a;
+}
+
+.query-chip-label {
+  white-space: nowrap;
+}
+
+.query-chip-remove {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.6;
+  padding: 0;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.query-chip-remove:hover {
+  opacity: 1;
+}
+
 .query-input-field input {
   flex: 1 1 0;
   height: 30px;

--- a/src/renderer/components/query-input/query-input.css
+++ b/src/renderer/components/query-input/query-input.css
@@ -89,9 +89,16 @@
   color: inherit;
   cursor: pointer;
   opacity: 0.6;
-  padding: 0;
   font-size: 14px;
   line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  /* Enlarge the click target without resizing the chip: pad the hit area, then
+     pull it back with negative margins (right cancels the chip's right padding,
+     left cancels the flex gap, vertical fills the chip height) so the chip's
+     box is unchanged but clicks anywhere around the glyph still remove it. */
+  padding: 5px 8px;
+  margin: -5px -8px -5px -5px;
 }
 
 .query-chip-remove:hover {

--- a/src/renderer/components/query-input/query-input.css
+++ b/src/renderer/components/query-input/query-input.css
@@ -48,6 +48,33 @@
   white-space: nowrap;
 }
 
+.query-chip-join {
+  border: none;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  padding: 1px 4px;
+  margin-right: 4px;
+  border-radius: 3px;
+  cursor: pointer;
+  line-height: 1;
+  background: #3a3f46;
+  color: #e6e6e6;
+}
+
+.query-chip-join:hover {
+  background: #4a505a;
+}
+
+.query-chip-join--or {
+  background: #5a4a2b;
+  color: #f5e3cf;
+}
+
+.query-chip-join--or:hover {
+  background: #6e5b35;
+}
+
 .query-chip-remove {
   background: none;
   border: none;

--- a/src/renderer/components/query-input/query-input.css
+++ b/src/renderer/components/query-input/query-input.css
@@ -30,6 +30,9 @@
   background: #2b3a4a;
   color: #cfe3f5;
   border: 1px solid #3d5a78;
+  /* Never let a long predicate value (e.g. a deep path) widen the chip past
+     the input. */
+  max-width: 100%;
 }
 
 .query-chip.exclude {
@@ -46,6 +49,11 @@
 
 .query-chip-label {
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* Truncate long values (deep paths, long descriptions) so the chip stays a
+     reasonable width; full value remains in the title tooltip. */
+  max-width: 220px;
 }
 
 .query-chip-join {

--- a/src/renderer/components/query-input/query-input.css
+++ b/src/renderer/components/query-input/query-input.css
@@ -112,7 +112,7 @@
   border: none;
   margin: 0.5rem;
   padding: 0.5rem;
-  padding-right: 80px;
+  padding-right: 105px;
   border-radius: 2px;
   color: #fff;
 }
@@ -157,6 +157,26 @@
 
 .query-input-help:hover {
   background: #5a5a5a !important;
+}
+
+/* Tag-filtering behaviour toggle (Intersection / Union / Exclusive). Sits to
+   the left of the query-syntax help button; its icon mirrors the taxonomy
+   sidebar's filtering-mode toggle. */
+.query-input-filter-mode {
+  right: 95px;
+  background: #4a4a4a !important;
+  border-radius: 2px;
+  transition: all 0.2s ease-in-out;
+  padding: 2px !important;
+}
+
+.query-input-filter-mode:hover {
+  background: #5a5a5a !important;
+}
+
+.query-input-filter-mode img {
+  width: 12px;
+  height: 12px;
 }
 
 .query-input-submit {

--- a/src/renderer/components/taxonomy/suggestion-sections.tsx
+++ b/src/renderer/components/taxonomy/suggestion-sections.tsx
@@ -102,6 +102,7 @@ export default function SuggestionSections({
           <div
             key={dir}
             className="suggestion-row"
+            title={dir}
             onClick={() =>
               onAdd({ type: 'path', value: dir, exclude: false })
             }

--- a/src/renderer/components/taxonomy/suggestion-sections.tsx
+++ b/src/renderer/components/taxonomy/suggestion-sections.tsx
@@ -1,0 +1,146 @@
+import { useQuery } from '@tanstack/react-query';
+import { invoke } from '../../platform';
+import type { Predicate } from '../../query/types';
+import './taxonomy.css';
+
+interface CategoryLite {
+  label: string;
+}
+
+interface SuggestionSectionsProps {
+  text: string; // active search term (non-empty when shown)
+  categories: CategoryLite[];
+  onAdd: (predicate: Predicate) => void;
+}
+
+const SECTION_CAP = 8;
+
+// Lazy media count for a single rendered category row. Only mounted for
+// categories that are actually shown, so we never fetch counts for the
+// filtered-out / capped categories.
+function CategoryCount({ label }: { label: string }) {
+  const { data: count } = useQuery<number, Error>(
+    ['suggest', 'category-count', label],
+    () => invoke('get-category-count', [label]) as Promise<number>,
+    { refetchOnWindowFocus: false }
+  );
+  if (count === undefined) return null;
+  return <span className="suggestion-meta">{count}</span>;
+}
+
+export default function SuggestionSections({
+  text,
+  categories,
+  onAdd,
+}: SuggestionSectionsProps) {
+  const term = text.toLowerCase();
+
+  // 1. Categories — substring match on label, capped.
+  const matchedCategories = categories
+    .filter((c) => c.label.toLowerCase().includes(term))
+    .slice(0, SECTION_CAP);
+
+  // 2. Paths — distinct directory fragments containing the term.
+  const { data: pathResults } = useQuery<string[], Error>(
+    ['suggest', 'paths', text],
+    () => invoke('load-path-suggestions', [text]) as Promise<string[]>,
+    { enabled: text.length > 0, refetchOnWindowFocus: false }
+  );
+
+  const distinctDirs: string[] = [];
+  if (pathResults) {
+    const seen = new Set<string>();
+    for (const full of pathResults) {
+      const segments = full.split(/[/\\]/);
+      for (const seg of segments) {
+        if (!seg) continue;
+        if (!seg.toLowerCase().includes(term)) continue;
+        if (seen.has(seg)) continue;
+        seen.add(seg);
+        distinctDirs.push(seg);
+        if (distinctDirs.length >= SECTION_CAP) break;
+      }
+      if (distinctDirs.length >= SECTION_CAP) break;
+    }
+  }
+
+  return (
+    <div className="suggestion-sections">
+      {matchedCategories.length > 0 && (
+        <div className="suggestion-section">
+          <div className="suggestion-section-label">Categories</div>
+          {matchedCategories.map((c) => (
+            <div
+              key={c.label}
+              className="suggestion-row suggestion-row-category"
+              onClick={() =>
+                onAdd({ type: 'category', value: c.label, exclude: false })
+              }
+            >
+              <span className="suggestion-prefix">in:</span>
+              <span className="suggestion-value">{c.label}</span>
+              <CategoryCount label={c.label} />
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="suggestion-section">
+        <div className="suggestion-section-label">Paths</div>
+        <div
+          className="suggestion-row suggestion-add-row"
+          onClick={() =>
+            onAdd({ type: 'path', value: text, exclude: false })
+          }
+        >
+          <span className="suggestion-add-badge">+</span>
+          <span className="suggestion-value">
+            path contains &quot;{text}&quot;
+          </span>
+        </div>
+        {distinctDirs.map((dir) => (
+          <div
+            key={dir}
+            className="suggestion-row"
+            onClick={() =>
+              onAdd({ type: 'path', value: dir, exclude: false })
+            }
+          >
+            <span className="suggestion-prefix">path:</span>
+            <span className="suggestion-value">{dir}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="suggestion-section">
+        <div className="suggestion-section-label">Description</div>
+        <div
+          className="suggestion-row suggestion-add-row"
+          onClick={() =>
+            onAdd({ type: 'description', value: text, exclude: false })
+          }
+        >
+          <span className="suggestion-add-badge">+</span>
+          <span className="suggestion-value">
+            description contains &quot;{text}&quot;
+          </span>
+        </div>
+      </div>
+
+      <div className="suggestion-section">
+        <div className="suggestion-section-label">Hash</div>
+        <div
+          className="suggestion-row suggestion-add-row"
+          onClick={() =>
+            onAdd({ type: 'hash', value: text, exclude: false })
+          }
+        >
+          <span className="suggestion-add-badge">+</span>
+          <span className="suggestion-value">
+            hash contains &quot;{text}&quot;
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/taxonomy/suggestion-sections.tsx
+++ b/src/renderer/components/taxonomy/suggestion-sections.tsx
@@ -1,16 +1,31 @@
+import { useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { debounce } from 'lodash';
 import { invoke } from '../../platform';
 import type { Predicate } from '../../query/types';
+import { SEARCH_DEBOUNCE_MS } from '../../search/search-config';
 import './taxonomy.css';
 
 interface CategoryLite {
   label: string;
 }
 
+// One navigable suggestion row: a stable key (unique across the whole results
+// surface) plus the predicate it commits when chosen.
+export interface SuggestionItem {
+  key: string;
+  predicate: Predicate;
+}
+
 interface SuggestionSectionsProps {
   text: string; // active search term (non-empty when shown)
   categories: CategoryLite[];
   onAdd: (predicate: Predicate) => void;
+  // Optional keyboard-navigation hooks (command palette). When omitted (e.g.
+  // the taxonomy sidebar) the section is click-only and behaves as before.
+  onItemsChange?: (items: SuggestionItem[]) => void; // report ordered rows
+  highlightedKey?: string | null; // row to render as highlighted
+  onHighlightKey?: (key: string) => void; // hover → move highlight here
 }
 
 const SECTION_CAP = 8;
@@ -32,19 +47,41 @@ export default function SuggestionSections({
   text,
   categories,
   onAdd,
+  onItemsChange,
+  highlightedKey,
+  onHighlightKey,
 }: SuggestionSectionsProps) {
-  const term = text.toLowerCase();
+  // Debounce the term that drives the IPC-backed suggestions (path lookups and
+  // the per-category counts mounted below) so they don't fire on every
+  // keystroke — the command palette passes the raw, un-debounced text. The
+  // "contains X" add-rows keep using the live `text` so the echoed term stays
+  // instant.
+  const [debouncedText, setDebouncedText] = useState<string>(text);
+  const debouncedSet = useRef(
+    debounce((value: string) => setDebouncedText(value), SEARCH_DEBOUNCE_MS)
+  );
+  useEffect(() => {
+    debouncedSet.current(text);
+  }, [text]);
+  useEffect(() => {
+    const d = debouncedSet.current;
+    return () => d.cancel();
+  }, []);
 
-  // 1. Categories — substring match on label, capped.
+  const term = debouncedText.toLowerCase();
+
+  // 1. Categories — substring match on label, capped. Driven by the debounced
+  // term so the per-category count IPC (CategoryCount) only fires once typing
+  // settles.
   const matchedCategories = categories
     .filter((c) => c.label.toLowerCase().includes(term))
     .slice(0, SECTION_CAP);
 
   // 2. Paths — distinct directory fragments containing the term.
   const { data: pathResults } = useQuery<string[], Error>(
-    ['suggest', 'paths', text],
-    () => invoke('load-path-suggestions', [text]) as Promise<string[]>,
-    { enabled: text.length > 0, refetchOnWindowFocus: false }
+    ['suggest', 'paths', debouncedText],
+    () => invoke('load-path-suggestions', [debouncedText]) as Promise<string[]>,
+    { enabled: debouncedText.length > 0, refetchOnWindowFocus: false }
   );
 
   const distinctDirs: string[] = [];
@@ -64,6 +101,56 @@ export default function SuggestionSections({
     }
   }
 
+  // Row keys for highlight matching + navigation. These also prefix the rows
+  // below so the rendered DOM order matches the reported item order exactly.
+  const CAT_KEY = (label: string) => `cat:${label}`;
+  const PATH_ADD_KEY = 'path:add';
+  const DIR_KEY = (dir: string) => `path:${dir}`;
+  const DESC_ADD_KEY = 'desc:add';
+  const HASH_ADD_KEY = 'hash:add';
+
+  // Ordered, navigable items — must mirror the render order below so arrow-key
+  // navigation lines up with what the user sees.
+  const items: SuggestionItem[] = [
+    ...matchedCategories.map((c) => ({
+      key: CAT_KEY(c.label),
+      predicate: { type: 'category', value: c.label, exclude: false } as Predicate,
+    })),
+    {
+      key: PATH_ADD_KEY,
+      predicate: { type: 'path', value: text, exclude: false } as Predicate,
+    },
+    ...distinctDirs.map((dir) => ({
+      key: DIR_KEY(dir),
+      predicate: { type: 'path', value: dir, exclude: false } as Predicate,
+    })),
+    {
+      key: DESC_ADD_KEY,
+      predicate: { type: 'description', value: text, exclude: false } as Predicate,
+    },
+    {
+      key: HASH_ADD_KEY,
+      predicate: { type: 'hash', value: text, exclude: false } as Predicate,
+    },
+  ];
+
+  // Report the ordered items to the parent. Keyed on the (key + value)
+  // signature so it only fires when the set actually changes — a fresh `items`
+  // array every render would otherwise loop with the parent's setState. The
+  // callback is read through a ref so its identity changing doesn't re-run it.
+  const onItemsChangeRef = useRef(onItemsChange);
+  onItemsChangeRef.current = onItemsChange;
+  const itemsSignature = items
+    .map((i) => `${i.key}=${i.predicate.value}`)
+    .join('|');
+  useEffect(() => {
+    onItemsChangeRef.current?.(items);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [itemsSignature]);
+
+  const rowClass = (key: string) =>
+    `suggestion-row${highlightedKey === key ? ' highlighted' : ''}`;
+
   return (
     <div className="suggestion-sections">
       {matchedCategories.length > 0 && (
@@ -72,7 +159,8 @@ export default function SuggestionSections({
           {matchedCategories.map((c) => (
             <div
               key={c.label}
-              className="suggestion-row suggestion-row-category"
+              className={`${rowClass(CAT_KEY(c.label))} suggestion-row-category`}
+              onMouseEnter={() => onHighlightKey?.(CAT_KEY(c.label))}
               onClick={() =>
                 onAdd({ type: 'category', value: c.label, exclude: false })
               }
@@ -88,10 +176,9 @@ export default function SuggestionSections({
       <div className="suggestion-section">
         <div className="suggestion-section-label">Paths</div>
         <div
-          className="suggestion-row suggestion-add-row"
-          onClick={() =>
-            onAdd({ type: 'path', value: text, exclude: false })
-          }
+          className={`${rowClass(PATH_ADD_KEY)} suggestion-add-row`}
+          onMouseEnter={() => onHighlightKey?.(PATH_ADD_KEY)}
+          onClick={() => onAdd({ type: 'path', value: text, exclude: false })}
         >
           <span className="suggestion-add-badge">+</span>
           <span className="suggestion-value">
@@ -101,11 +188,10 @@ export default function SuggestionSections({
         {distinctDirs.map((dir) => (
           <div
             key={dir}
-            className="suggestion-row"
+            className={rowClass(DIR_KEY(dir))}
             title={dir}
-            onClick={() =>
-              onAdd({ type: 'path', value: dir, exclude: false })
-            }
+            onMouseEnter={() => onHighlightKey?.(DIR_KEY(dir))}
+            onClick={() => onAdd({ type: 'path', value: dir, exclude: false })}
           >
             <span className="suggestion-prefix">path:</span>
             <span className="suggestion-value">{dir}</span>
@@ -116,7 +202,8 @@ export default function SuggestionSections({
       <div className="suggestion-section">
         <div className="suggestion-section-label">Description</div>
         <div
-          className="suggestion-row suggestion-add-row"
+          className={`${rowClass(DESC_ADD_KEY)} suggestion-add-row`}
+          onMouseEnter={() => onHighlightKey?.(DESC_ADD_KEY)}
           onClick={() =>
             onAdd({ type: 'description', value: text, exclude: false })
           }
@@ -131,10 +218,9 @@ export default function SuggestionSections({
       <div className="suggestion-section">
         <div className="suggestion-section-label">Hash</div>
         <div
-          className="suggestion-row suggestion-add-row"
-          onClick={() =>
-            onAdd({ type: 'hash', value: text, exclude: false })
-          }
+          className={`${rowClass(HASH_ADD_KEY)} suggestion-add-row`}
+          onMouseEnter={() => onHighlightKey?.(HASH_ADD_KEY)}
+          onClick={() => onAdd({ type: 'hash', value: text, exclude: false })}
         >
           <span className="suggestion-add-badge">+</span>
           <span className="suggestion-value">

--- a/src/renderer/components/taxonomy/tag-search.worker.ts
+++ b/src/renderer/components/taxonomy/tag-search.worker.ts
@@ -1,0 +1,70 @@
+/**
+ * Tag search worker.
+ *
+ * Runs Fuse.js indexing and fuzzy matching off the renderer's main thread so
+ * a large tag library (tens of thousands of entries) can't block the search
+ * input. The renderer posts the full tag set whenever it changes ('index')
+ * and a query per debounced keystroke ('search'); we reply with the ranked,
+ * capped match list tagged with the request id so the renderer can discard
+ * stale responses.
+ *
+ * Keep the Fuse options here in sync with the synchronous fallback in
+ * taxonomy.tsx (used where Web Workers aren't available).
+ */
+import Fuse from 'fuse.js';
+
+type Concept = {
+  label: string;
+  category: string;
+  weight: number;
+  description: string;
+};
+
+type IndexMessage = { type: 'index'; tags: Concept[] };
+type SearchMessage = {
+  type: 'search';
+  id: number;
+  query: string;
+  limit: number;
+};
+type InMessage = IndexMessage | SearchMessage;
+
+const ctx = self as unknown as Worker;
+
+let fuse: Fuse<Concept> | null = null;
+// The most recent search request, retained so a (re)built index can re-run the
+// outstanding query: the renderer may search before the tag data has arrived,
+// and the data can change underneath an active search (e.g. after a mutation).
+let lastSearch: SearchMessage | null = null;
+
+function buildFuse(tags: Concept[]): Fuse<Concept> {
+  return new Fuse(tags, {
+    keys: [
+      { name: 'label', weight: 2 },
+      { name: 'category', weight: 1 },
+    ],
+    threshold: 0.4,
+    ignoreLocation: true,
+    minMatchCharLength: 1,
+  });
+}
+
+function runSearch(req: SearchMessage) {
+  if (!fuse || !req.query) return;
+  const items = fuse.search(req.query, { limit: req.limit }).map((r) => r.item);
+  ctx.postMessage({ type: 'result', id: req.id, query: req.query, items });
+}
+
+ctx.onmessage = (e: MessageEvent<InMessage>) => {
+  const msg = e.data;
+  if (msg.type === 'index') {
+    fuse = buildFuse(msg.tags || []);
+    // Refresh whatever the user is currently looking at against the new index.
+    if (lastSearch) runSearch(lastSearch);
+    return;
+  }
+  if (msg.type === 'search') {
+    lastSearch = msg;
+    runSearch(msg);
+  }
+};

--- a/src/renderer/components/taxonomy/taxonomy.css
+++ b/src/renderer/components/taxonomy/taxonomy.css
@@ -210,7 +210,11 @@
   grid-template-rows: none;
   grid-gap: 0.5rem;
   flex: 8 1 0;
-  overflow: auto;
+  /* Vertical-only: these are width-fitting grids/lists that should never
+     scroll sideways. `overflow: auto` on both axes produced a phantom
+     horizontal scrollbar once the vertical scrollbar claimed its ~6px. */
+  overflow-x: hidden;
+  overflow-y: auto;
   padding-bottom: 77px;
   height: 100%;
 }
@@ -218,7 +222,8 @@
 .Taxonomy .tags.virtualized {
   display: block;
   flex: 8 1 0;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding-bottom: 77px;
   height: 100%;
 }
@@ -226,14 +231,17 @@
 .Taxonomy .tag-list-view {
   display: block;
   flex: 8 1 0;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding-bottom: 77px;
   height: 100%;
   /* Block flex items default to min-height: auto (= content size).
      The virtualized inner div is thousands of px tall, which would
      otherwise expand this container and disable scrolling. */
   min-height: 0;
-  background-color: #161416;
+  /* No solid background: rows are now individual pills with transparent gaps,
+     so the panel shows through between them. */
+  background-color: transparent;
 }
 
 /* Blended search view: card grid on top (locked, scrolls within its own
@@ -266,9 +274,23 @@
 .Taxonomy .tags-blended .suggested-section {
   display: flex;
   flex-direction: column;
-  flex: 1 1 0;
+  /* Size to content instead of filling the remaining height — a handful of
+     suggested tags should not reserve the whole lower half of the panel. */
+  flex: 0 1 auto;
   min-height: 0;
   margin-top: 0.5rem;
+}
+
+/* The suggested list is virtualized, so it needs a bounded scroll height —
+   but only as a CAP. height: auto lets it shrink to its actual content (the
+   virtualizer's intrinsic sizer height) when there are just a few items, and
+   max-height caps it so long lists scroll instead of growing without bound.
+   Drop the 77px bottom padding here: this list isn't against the panel edge. */
+.Taxonomy .tags-blended .suggested-section .tag-list-view {
+  flex: 0 1 auto;
+  height: auto;
+  max-height: 400px;
+  padding-bottom: 0;
 }
 
 .Taxonomy .tags-blended .suggested-heading {
@@ -279,6 +301,133 @@
   padding: 0.6rem 0.4rem 0.35rem;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
   flex: 0 0 auto;
+}
+
+/* ── Search-results area ──────────────────────────────────────────────────
+   Holds two panes: the tag results (cards / list) and the SuggestionSections
+   column (categories / paths / description / hash). This replaces what used
+   to be two separate flex children of .Taxonomy.
+
+   It is a container-query context (`container-type: inline-size`) so it reacts
+   to its OWN width rather than the viewport — the taxonomy panel is
+   user-resizable and docks either left (tall/narrow) or bottom (wide/short),
+   so viewport media queries can't capture how much room these panes actually
+   have. Default is a single stacked column; it splits into two columns only
+   when wide enough (see the @container block below).
+
+   Empty regions collapse rather than reserve blank space: the panes are
+   rendered conditionally in taxonomy.tsx (`has-results` / `has-suggestions`),
+   so whichever pane is present grows to fill. */
+/* Outer wrapper exists ONLY to establish the container-query context. A
+   container query can style a container's DESCENDANTS but not the container
+   element itself — so the stacked⇄row switch below must live on the inner
+   .search-results, which is a descendant of this wrapper. */
+.Taxonomy .search-results-container {
+  flex: 8 1 0;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  display: flex;
+  overflow: hidden;
+  container-type: inline-size;
+}
+
+.Taxonomy .search-results {
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow: hidden;
+}
+
+.Taxonomy .search-results .results-pane,
+.Taxonomy .search-results .suggestions-pane {
+  display: flex;
+  flex-direction: column;
+  /* min-* lets the panes shrink below content width so long paths can
+     ellipsis-truncate and the inner virtualized lists can scroll. */
+  min-width: 0;
+  min-height: 0;
+}
+
+.Taxonomy .search-results .results-pane {
+  flex: 1 1 0;
+  overflow: hidden;
+}
+
+/* Stacked layout with BOTH panes: size the results to their content (capped)
+   rather than filling the column, so the suggestions sit directly beneath the
+   results instead of being pushed to the bottom behind a large empty gap.
+   .search-results has a definite height, so this 65% cap resolves; once the
+   results exceed it the inner grid scrolls internally. (The two-column row
+   layout overrides this back to fill — see the @container block.) */
+.Taxonomy .search-results.has-results.has-suggestions .results-pane {
+  flex: 0 1 auto;
+  max-height: 65%;
+}
+
+/* The inner result elements were authored as direct children of .Taxonomy
+   (flex: 8, height: 100%). Inside the results-pane they fill it — but with
+   flex-basis auto (not 0) so the pane can also size to this content in the
+   stacked case above. */
+.Taxonomy .search-results .results-pane > .tags,
+.Taxonomy .search-results .results-pane > .tags.virtualized,
+.Taxonomy .search-results .results-pane > .tag-list-view,
+.Taxonomy .search-results .results-pane > .tags-blended {
+  flex: 1 1 auto;
+  height: auto;
+  min-height: 0;
+}
+
+/* Suggestions pane. When it is the only pane (no tag matches) it fills the
+   whole area; when shown alongside results in the STACKED layout it is capped
+   so the results stay visible above it. */
+.Taxonomy .search-results .suggestions-pane {
+  flex: 1 1 0;
+  /* Never scroll horizontally — long paths/descriptions truncate with an
+     ellipsis instead (see .suggestion-value). */
+  overflow-x: hidden;
+  overflow-y: auto;
+  /* Clear the floating controls/overlay at the bottom of the panel so the
+     last rows can scroll into view instead of sitting underneath it
+     (matches the padding the other scroll areas use). */
+  padding-bottom: 77px;
+}
+
+.Taxonomy .search-results.has-results .suggestions-pane {
+  flex: 0 1 auto;
+  max-height: 45%;
+}
+
+/* Wide enough for two side-by-side columns. We split with flex-direction:row
+   (NOT grid): the pane heights then come from flex cross-axis stretch, the
+   same robust mechanism the original .tags layout used. A grid with
+   `grid-template-rows: 100%` resolves to an indefinite height here and
+   collapses the virtualized grid's scroll element to 0 — which made the tags
+   disappear at wide sizes. Only applies when BOTH panes are present;
+   otherwise the single pane keeps the full width via the stacked rules. */
+@container (min-width: 440px) {
+  .Taxonomy .search-results.has-results.has-suggestions {
+    flex-direction: row;
+    align-items: stretch;
+  }
+
+  /* Two columns: results fill the left at full height (via stretch) — NOT the
+     content-sized/capped behaviour used when stacked. */
+  .Taxonomy .search-results.has-results.has-suggestions .results-pane {
+    flex: 1 1 0;
+    max-height: none;
+  }
+
+  /* Fixed-width right column so long path matches can't widen it; the
+     results pane (flex: 1 1 0, min-width: 0) takes the rest. */
+  .Taxonomy .search-results.has-results.has-suggestions .suggestions-pane {
+    flex: 0 0 clamp(180px, 30%, 280px);
+    max-height: none;
+  }
 }
 
 
@@ -341,31 +490,35 @@
 .Taxonomy .tag-list-row {
   display: flex;
   align-items: center;
-  height: 100%;
+  /* The virtualizer gives each row a fixed 30px slot. We inset the row inside
+     that slot (height + vertical margin) so consecutive items are separated by
+     a transparent gap and read as individual pills rather than a solid list. */
+  height: calc(100% - 4px);
+  margin: 2px 0;
   padding: 0 96px 0 14px;
-  background-color: transparent;
+  background-color: rgba(255, 255, 255, 0.035);
+  border-radius: 4px;
   color: rgba(255, 255, 255, 0.62);
   cursor: pointer;
   position: relative;
   font-size: 0.78rem;
   letter-spacing: 0.1px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
   transition: background-color 0.12s ease, color 0.12s ease;
 }
 
 .Taxonomy .tag-list-row:hover {
-  background-color: rgba(255, 255, 255, 0.04);
+  background-color: rgba(255, 255, 255, 0.07);
   color: rgba(255, 255, 255, 0.95);
 }
 
 .Taxonomy .tag-list-row.active {
-  background-color: rgba(110, 90, 140, 0.28);
+  background-color: rgba(110, 90, 140, 0.3);
   color: #fff;
   box-shadow: inset 2px 0 0 rgb(150, 110, 180);
 }
 
 .Taxonomy .tag-list-row.active:hover {
-  background-color: rgba(120, 100, 150, 0.34);
+  background-color: rgba(120, 100, 150, 0.36);
 }
 
 .Taxonomy .tag-list-row.disabled {
@@ -374,15 +527,17 @@
 }
 
 .Taxonomy .tag-list-row .label {
-  display: block;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
   flex: 1 1 0;
   min-width: 0;
   text-align: left;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  line-height: 30px;
-  align-self: center;
+  line-height: 1;
+  align-self: stretch;
 }
 
 .Taxonomy .tag-list-row .actions {
@@ -641,48 +796,58 @@
   width: 100%;
 }
 
-/* Type-ahead suggestion sections (categories / paths / description / hash) */
+/* Type-ahead suggestion sections (categories / paths / description / hash).
+   Styled to match the tag list view: the pane has no panel background of its
+   own, and each row is an individual pill with a subtle background and a
+   transparent gap between items. */
 .suggestion-sections {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 8px 6px;
+  gap: 12px;
+  padding: 4px 0;
 }
 
 .suggestion-section {
   display: flex;
   flex-direction: column;
+  gap: 4px;
 }
 
 .suggestion-section-label {
-  font-size: 10px;
+  font-size: 0.62rem;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: #777;
-  padding: 2px 8px 4px;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.4);
+  padding: 0 6px 2px 14px;
 }
 
 .suggestion-row {
   display: flex;
   align-items: center;
-  gap: 6px;
-  height: 28px;
-  padding: 0 8px;
-  font-size: 12px;
-  color: #ddd;
+  gap: 8px;
+  height: 26px;
+  padding: 0 10px 0 14px;
+  font-size: 0.78rem;
+  letter-spacing: 0.1px;
+  color: rgba(255, 255, 255, 0.62);
+  background-color: rgba(255, 255, 255, 0.035);
+  border-radius: 4px;
   cursor: pointer;
-  border-radius: 3px;
+  position: relative;
   overflow: hidden;
   white-space: nowrap;
+  transition: background-color 0.12s ease, color 0.12s ease;
 }
 
 .suggestion-row:hover {
-  background: #222;
+  background-color: rgba(255, 255, 255, 0.07);
+  color: rgba(255, 255, 255, 0.95);
 }
 
 .suggestion-prefix {
-  color: #888;
+  color: rgba(255, 255, 255, 0.35);
   flex: 0 0 auto;
+  font-size: 0.7rem;
 }
 
 .suggestion-value {
@@ -694,12 +859,25 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-align: left;
 }
 
 .suggestion-meta {
   flex: 0 0 auto;
-  color: #777;
-  font-size: 11px;
+  display: inline-flex;
+  align-items: center;
+  height: 16px;
+  padding: 1px 7px;
+  font-size: 0.66rem;
+  font-variant-numeric: tabular-nums;
+  background-color: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.55);
+  border-radius: 9px;
+}
+
+.suggestion-row:hover .suggestion-meta {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.8);
 }
 
 .suggestion-row-category .suggestion-prefix {
@@ -707,12 +885,11 @@
 }
 
 .suggestion-add-row {
-  border-left: 2px dashed #4a4a4a;
-  color: #bbb;
+  color: rgba(255, 255, 255, 0.55);
 }
 
-.suggestion-add-row:hover {
-  border-left-color: #6a6a6a;
+.suggestion-add-row .suggestion-value {
+  font-style: italic;
 }
 
 .suggestion-add-badge {
@@ -720,11 +897,11 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   border-radius: 3px;
-  background: #333;
-  color: #aaa;
-  font-size: 11px;
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 12px;
   line-height: 1;
 }

--- a/src/renderer/components/taxonomy/taxonomy.css
+++ b/src/renderer/components/taxonomy/taxonomy.css
@@ -1,10 +1,26 @@
 .Taxonomy {
   display: flex;
-  flex-wrap: wrap;
+  /* Column: the search bar is an auto-height top row, then .taxonomy-body fills
+     the rest. Previously this was a wrapping flex row where the content items
+     used height:100% — but on the wrapped second line that resolves to the FULL
+     panel height, so the results/list overhung the panel bottom by the search
+     bar's height and the last row was clipped under the bottom overlay. */
+  flex-direction: column;
   margin: 0.3rem 0.2rem;
   width: 100%;
   height: 100%;
   overflow: hidden;
+}
+
+/* Fills the height remaining under the search bar. The content columns
+   (controls / categories / new-tag / results) size their height:100% against
+   THIS row, so their scroll areas keep their full bottom padding. */
+.Taxonomy .taxonomy-body {
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: row;
+  width: 100%;
 }
 
 .Placeholder {
@@ -21,7 +37,7 @@
 
 .Taxonomy .search {
   display: flex;
-  flex: 1 1 100%;
+  flex: 0 0 auto;
   flex-direction: row;
   margin-bottom: 8px;
 }
@@ -772,7 +788,7 @@
   flex-direction: column;
 }
 
-.Taxonomy > .controls button {
+.Taxonomy .controls button {
   background: none;
   border: none;
   cursor: pointer;

--- a/src/renderer/components/taxonomy/taxonomy.css
+++ b/src/renderer/components/taxonomy/taxonomy.css
@@ -687,8 +687,13 @@
 
 .suggestion-value {
   flex: 1 1 auto;
+  /* min-width: 0 lets this flex item shrink below its intrinsic content width
+     so long path/description matches truncate with an ellipsis instead of
+     widening the whole results column. */
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .suggestion-meta {

--- a/src/renderer/components/taxonomy/taxonomy.css
+++ b/src/renderer/components/taxonomy/taxonomy.css
@@ -640,3 +640,86 @@
 .Taxonomy .controls button img {
   width: 100%;
 }
+
+/* Type-ahead suggestion sections (categories / paths / description / hash) */
+.suggestion-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 8px 6px;
+}
+
+.suggestion-section {
+  display: flex;
+  flex-direction: column;
+}
+
+.suggestion-section-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #777;
+  padding: 2px 8px 4px;
+}
+
+.suggestion-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 8px;
+  font-size: 12px;
+  color: #ddd;
+  cursor: pointer;
+  border-radius: 3px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.suggestion-row:hover {
+  background: #222;
+}
+
+.suggestion-prefix {
+  color: #888;
+  flex: 0 0 auto;
+}
+
+.suggestion-value {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.suggestion-meta {
+  flex: 0 0 auto;
+  color: #777;
+  font-size: 11px;
+}
+
+.suggestion-row-category .suggestion-prefix {
+  color: #5fa978;
+}
+
+.suggestion-add-row {
+  border-left: 2px dashed #4a4a4a;
+  color: #bbb;
+}
+
+.suggestion-add-row:hover {
+  border-left-color: #6a6a6a;
+}
+
+.suggestion-add-badge {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  background: #333;
+  color: #aaa;
+  font-size: 11px;
+  line-height: 1;
+}

--- a/src/renderer/components/taxonomy/taxonomy.css
+++ b/src/renderer/components/taxonomy/taxonomy.css
@@ -844,6 +844,21 @@
   color: rgba(255, 255, 255, 0.95);
 }
 
+/* Keyboard-navigation highlight (command palette). Stronger than hover and
+   marked with an accent bar so the active row is unambiguous as arrow keys
+   move through tags and suggestions. Inset box-shadow avoids any layout shift
+   against the row's border-radius/overflow. */
+.suggestion-row.highlighted {
+  background-color: rgba(95, 169, 120, 0.16);
+  color: rgba(255, 255, 255, 0.98);
+  box-shadow: inset 2px 0 0 0 #5fa978;
+}
+
+.suggestion-row.highlighted .suggestion-meta {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.8);
+}
+
 .suggestion-prefix {
   color: rgba(255, 255, 255, 0.35);
   flex: 0 0 auto;

--- a/src/renderer/components/taxonomy/taxonomy.tsx
+++ b/src/renderer/components/taxonomy/taxonomy.tsx
@@ -4,11 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import { debounce } from 'lodash';
 import { Tooltip } from 'react-tooltip';
 import { GlobalStateContext } from '../../state';
-import { FilterModeOption, getNextFilterMode } from '../../../settings';
+import { getNextFilterMode } from '../../../settings';
 import restart from '../../../../assets/restart.svg';
-import union from '../../../../assets/union.svg';
-import intersect from '../../../../assets/intersect.svg';
-import selective from '../../../../assets/selective.svg';
 import group from '../../../../assets/group.svg';
 import addMediaImage from '../../../../assets/add-media-image.svg';
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
@@ -46,10 +43,6 @@ type Category = {
   tagViewMode?: TagViewMode;
 };
 
-type FilterModeIconMap = {
-  [key in FilterModeOption]: string;
-};
-
 // Loaders for the three taxonomy slices. Each is a separate React Query so
 // the panel can fetch categories cheaply, then lazy-load per-category tags
 // and the full tag list (for search) only when needed.
@@ -68,12 +61,6 @@ async function loadAllTags(): Promise<Concept[]> {
   const result = await invoke('load-all-tags', []);
   return (result as Concept[]) ?? [];
 }
-
-const filteringModeIcons: FilterModeIconMap = {
-  OR: union,
-  AND: intersect,
-  EXCLUSIVE: selective,
-};
 
 export default function Taxonomy() {
   const categoryListRef = useRef<HTMLDivElement>(null);
@@ -164,17 +151,22 @@ export default function Taxonomy() {
   // broad invalidations (`queryClient.invalidateQueries(['taxonomy'])`) keep
   // working. staleTime: Infinity means remounts within a session never refetch
   // — mutations and DB swaps (initSessionId) are what trigger reloads.
+  // All three taxonomy fetches are gated on initSessionId, which the state
+  // machine only assigns once it reaches its post-DB `init` state. The taxonomy
+  // sidebar mounts during boot, so without this gate these queries fire before
+  // load-db registers their IPC handlers and fail with "No handler registered"
+  // on every launch (the fetch then succeeds on retry, but the error is logged).
   const { data: categories } = useQuery<Category[], Error>(
     ['taxonomy', 'categories', initSessionId],
     loadCategories,
-    { staleTime: Infinity }
+    { enabled: !!initSessionId, staleTime: Infinity }
   );
 
   const { data: activeCategoryTags, isFetching: isFetchingCategoryTags } =
     useQuery<Concept[], Error>(
       ['taxonomy', 'category-tags', activeCategory, initSessionId],
       () => loadCategoryTags(activeCategory),
-      { enabled: !!activeCategory, staleTime: Infinity }
+      { enabled: !!activeCategory && !!initSessionId, staleTime: Infinity }
     );
 
   // Warmed as soon as the search input gains focus (or, as a fallback, on the
@@ -185,7 +177,7 @@ export default function Taxonomy() {
     Concept[],
     Error
   >(['taxonomy', 'all-tags', initSessionId], loadAllTags, {
-    enabled: searchFocused || !!tagFilterInput,
+    enabled: (searchFocused || !!tagFilterInput) && !!initSessionId,
     staleTime: Infinity,
   });
 
@@ -362,19 +354,6 @@ export default function Taxonomy() {
             }
           >
             <img src={restart} />
-          </button>
-          <button
-            className={'active'}
-            data-tooltip-id="filtering-mode"
-            data-tooltip-delay-show={500}
-            onClick={() =>
-              libraryService.send({
-                type: 'CHANGE_SETTING',
-                data: { filteringMode: getNextFilterMode(filteringMode) },
-              })
-            }
-          >
-            <img src={filteringModeIcons[filteringMode]} />
           </button>
           <button
             className={`${applyTagToAll ? 'active' : ''}`}
@@ -676,11 +655,6 @@ export default function Taxonomy() {
       <Tooltip
         id="reset-query-tag"
         content={`Reset tag filter.`}
-        place="right"
-      />
-      <Tooltip
-        id="filtering-mode"
-        content={`Filtering mode. (Exclusive, Intersection, Union)`}
         place="right"
       />
       <Tooltip

--- a/src/renderer/components/taxonomy/taxonomy.tsx
+++ b/src/renderer/components/taxonomy/taxonomy.tsx
@@ -8,7 +8,6 @@ import { GlobalStateContext } from '../../state';
 import { FilterModeOption, getNextFilterMode } from '../../../settings';
 import restart from '../../../../assets/restart.svg';
 import union from '../../../../assets/union.svg';
-import clear from '../../../../assets/cancel.svg';
 import intersect from '../../../../assets/intersect.svg';
 import selective from '../../../../assets/selective.svg';
 import group from '../../../../assets/group.svg';
@@ -93,10 +92,8 @@ export default function Taxonomy() {
       return state.context.settings;
     });
 
-  const textFilter = useSelector(
-    libraryService,
-    (state) => state.context.textFilter
-  );
+  // The unified query (chips) shown in QueryInput.
+  const query = useSelector(libraryService, (state) => state.context.query);
 
   const state = useSelector(
     libraryService,
@@ -105,21 +102,6 @@ export default function Taxonomy() {
       return a.matches(b);
     }
   );
-  const [newTextFilter, setNewTextFilter] = useState<string>('');
-
-  function setTextFilter(text: string) {
-    libraryService.send({
-      type: 'SET_TEXT_FILTER',
-      data: { textFilter: text },
-    });
-  }
-
-  // If textFilter changes, update the input field
-  useEffect(() => {
-    if (textFilter !== newTextFilter) {
-      setNewTextFilter(textFilter);
-    }
-  }, [textFilter]);
 
   // Two-tier search state: tagFilterInput updates on every keystroke so the
   // input feels responsive; tagFilter is the debounced value dispatched to the
@@ -390,45 +372,50 @@ export default function Taxonomy() {
       >
         <div className="search">
           <QueryInput
-            value={newTextFilter}
-            onChange={setNewTextFilter}
-            onSubmit={(text) => {
-              setNewTextFilter(text);
-              setTextFilter(text);
+            query={query}
+            textValue={tagFilterInput}
+            onTextChange={setTagFilterInput}
+            onFocus={() => setSearchFocused(true)}
+            onSubmitText={() => {
+              // Commit the top tag suggestion as a predicate, then clear text.
+              const top = searchResults[0];
+              if (top) {
+                libraryService.send({
+                  type: 'ADD_PREDICATE',
+                  data: {
+                    predicate: {
+                      type: 'tag',
+                      value: top.label,
+                      exclude: false,
+                    },
+                  },
+                });
+                setTagFilterInput('');
+                setTagFilter('');
+                debouncedSetTagFilter.current.cancel();
+              }
             }}
-            onClear={() => {
-              setNewTextFilter('');
-              setTextFilter('');
+            onRemovePredicate={(key) =>
+              libraryService.send({
+                type: 'REMOVE_PREDICATE',
+                data: { key },
+              })
+            }
+            onToggleExclude={(key) =>
+              libraryService.send({
+                type: 'TOGGLE_EXCLUDE',
+                data: { key },
+              })
+            }
+            onClearAll={() => {
+              libraryService.send({ type: 'CLEAR_QUERY' });
+              setTagFilterInput('');
+              setTagFilter('');
+              debouncedSetTagFilter.current.cancel();
               setEditingTag(null);
             }}
             disabled={isDisabled}
           />
-          <div className="textSearch">
-            <input
-              type="text"
-              placeholder="Search Tags"
-              value={tagFilterInput}
-              onFocus={() => setSearchFocused(true)}
-              onKeyDown={(e) => {
-                e.stopPropagation();
-              }}
-              onKeyUp={(e) => {
-                e.stopPropagation();
-              }}
-              onChange={(e) => setTagFilterInput(e.currentTarget.value)}
-            />
-            <button
-              className="clear-search"
-              onClick={() => {
-                setTagFilterInput('');
-                setTagFilter('');
-                debouncedSetTagFilter.current.cancel();
-                setEditingTag(null);
-              }}
-            >
-              <img src={clear} />
-            </button>
-          </div>
         </div>
         <div className="controls">
           <button

--- a/src/renderer/components/taxonomy/taxonomy.tsx
+++ b/src/renderer/components/taxonomy/taxonomy.tsx
@@ -2,7 +2,6 @@ import { useState, useContext, useRef, useEffect, useMemo } from 'react';
 import { useSelector } from '@xstate/react';
 import { useQuery } from '@tanstack/react-query';
 import { debounce } from 'lodash';
-import Fuse from 'fuse.js';
 import { Tooltip } from 'react-tooltip';
 import { GlobalStateContext } from '../../state';
 import { FilterModeOption, getNextFilterMode } from '../../../settings';
@@ -25,19 +24,17 @@ import Category from './category';
 import SuggestionSections from './suggestion-sections';
 import { invoke } from '../../platform';
 import QueryInput from '../query-input/QueryInput';
+import { useTagSearch } from '../../hooks/useTagSearch';
 
 const VIRTUALIZE_THRESHOLD = 300;
-// Hard cap on search results. Each rendered <Tag> fires an IPC call to
-// fetch its preview, so an unbounded match list (e.g. 1-char query against
-// a 50k-tag library) used to flood the renderer + main process and freeze
-// the app. Fuse still ranks across the full set; we only render the top N.
-const MAX_SEARCH_RESULTS = 200;
 
 type Concept = {
   label: string;
   category: string;
   weight: number;
-  description: string;
+  // Optional so the shared useTagSearch results (TagConcept, description?:) are
+  // assignable to Concept-typed row renderers.
+  description?: string;
 };
 
 type TagViewMode = 'card' | 'list';
@@ -245,100 +242,11 @@ export default function Taxonomy() {
     }
   }
 
-  // The full-tag list is only fetched lazily for search; defensive filter
-  // drops tags without a label — Fuse and the row components both assume
-  // a non-empty string and would otherwise throw when one slips in.
-  const allTags = useMemo(() => {
-    if (!allTagsData) return [] as Concept[];
-    return allTagsData.filter(
-      (t) => t && typeof t.label === 'string' && t.label.length > 0
-    );
-  }, [allTagsData]);
-
-  // Async tag search. Indexing and fuzzy matching run in a Web Worker so a
-  // large library (tens of thousands of tags) never blocks the input. Each
-  // request carries an id (searchSeq); responses that aren't the latest are
-  // dropped so a slow earlier search can't clobber newer results.
-  const workerRef = useRef<Worker | null>(null);
-  const searchSeq = useRef(0);
-  const [searchResults, setSearchResults] = useState<Concept[]>([]);
-  // Optimistically assume worker support; flip to false if construction fails
-  // (e.g. jsdom in tests) so the synchronous fallback below takes over.
-  const [workerReady, setWorkerReady] = useState<boolean>(
-    typeof Worker !== 'undefined'
-  );
-
-  useEffect(() => {
-    if (typeof Worker === 'undefined') {
-      setWorkerReady(false);
-      return undefined;
-    }
-    let worker: Worker;
-    try {
-      worker = new Worker(new URL('./tag-search.worker.ts', import.meta.url));
-    } catch {
-      setWorkerReady(false);
-      return undefined;
-    }
-    worker.onmessage = (e: MessageEvent) => {
-      const msg = e.data;
-      if (msg?.type === 'result' && msg.id === searchSeq.current) {
-        setSearchResults(msg.items as Concept[]);
-      }
-    };
-    workerRef.current = worker;
-    setWorkerReady(true);
-    return () => {
-      worker.terminate();
-      workerRef.current = null;
-    };
-  }, []);
-
-  // Keep the worker's index in sync with the loaded tag set. The worker
-  // re-runs the outstanding query after re-indexing, so results refresh
-  // automatically once data first arrives or after a tag mutation.
-  useEffect(() => {
-    workerRef.current?.postMessage({ type: 'index', tags: allTags });
-  }, [allTags]);
-
-  // Synchronous Fuse fallback — only built/used when no worker is available.
-  // Keep these options in sync with tag-search.worker.ts.
-  const fallbackFuse = useMemo(() => {
-    if (workerReady) return null;
-    return new Fuse(allTags, {
-      keys: [
-        { name: 'label', weight: 2 },
-        { name: 'category', weight: 1 },
-      ],
-      threshold: 0.4,
-      ignoreLocation: true,
-      minMatchCharLength: 1,
-    });
-  }, [allTags, workerReady]);
-
-  // Dispatch the debounced query. With a worker the match happens off-thread
-  // and arrives via onmessage; without one we fall back to a synchronous
-  // search. Bumping searchSeq invalidates any in-flight worker response.
-  useEffect(() => {
-    const id = (searchSeq.current += 1);
-    if (!tagFilter) {
-      setSearchResults([]);
-    }
-    if (workerRef.current) {
-      workerRef.current.postMessage({
-        type: 'search',
-        id,
-        query: tagFilter,
-        limit: MAX_SEARCH_RESULTS,
-      });
-    } else if (fallbackFuse && tagFilter) {
-      setSearchResults(
-        fallbackFuse
-          .search(tagFilter, { limit: MAX_SEARCH_RESULTS })
-          .map((r) => r.item)
-      );
-    }
-  }, [tagFilter, fallbackFuse]);
+  // Tag search now runs through the shared, pre-warmed singleton index (one
+  // worker for the whole app) via useTagSearch. We pass the already-debounced
+  // tagFilter; the hook debounces again (harmless) and returns ranked,
+  // pre-capped matches across all categories.
+  const { results: searchResults } = useTagSearch(tagFilter, !!tagFilter);
 
   const tags = useMemo(() => {
     if (tagFilter) {

--- a/src/renderer/components/taxonomy/taxonomy.tsx
+++ b/src/renderer/components/taxonomy/taxonomy.tsx
@@ -323,6 +323,12 @@ export default function Taxonomy() {
                 data: { key, join },
               })
             }
+            onClearText={() => {
+              setTagFilterInput('');
+              setTagFilter('');
+              debouncedSetTagFilter.current.cancel();
+              setEditingTag(null);
+            }}
             onClearAll={() => {
               libraryService.send({ type: 'CLEAR_QUERY' });
               setTagFilterInput('');

--- a/src/renderer/components/taxonomy/taxonomy.tsx
+++ b/src/renderer/components/taxonomy/taxonomy.tsx
@@ -418,155 +418,195 @@ export default function Taxonomy() {
           </div>
         )}
         {(() => {
-          if (!(activeCategory || tagFilter)) {
-            return <div className={`tags`} />;
-          }
-          // Search results span categories — always use card style.
-          // For an active category, honour its persisted tagViewMode.
-          const activeViewMode: TagViewMode = tagFilter
-            ? 'card'
-            : (categoriesByLabel[activeCategory]?.tagViewMode as TagViewMode) ||
-              'card';
-          // Reordering by drag is meaningless when results are sorted by
-          // search relevance — disable DnD while a search is active.
-          const disableReorder = !!tagFilter;
+          // The search-results area holds two panes: the tag results (cards /
+          // list) on the left and the SuggestionSections column (categories /
+          // paths / description / hash) on the right. taxonomy.css drives the
+          // responsive two-column ⇄ stacked behaviour via a container query on
+          // `.search-results`; here we only decide which panes exist so empty
+          // regions collapse instead of reserving blank space.
+          const resultsEl = (() => {
+            if (!(activeCategory || tagFilter)) {
+              return <div className={`tags`} />;
+            }
+            // Search results span categories — always use card style.
+            // For an active category, honour its persisted tagViewMode.
+            const activeViewMode: TagViewMode = tagFilter
+              ? 'card'
+              : (categoriesByLabel[activeCategory]
+                  ?.tagViewMode as TagViewMode) || 'card';
+            // Reordering by drag is meaningless when results are sorted by
+            // search relevance — disable DnD while a search is active.
+            const disableReorder = !!tagFilter;
 
-          // Skeleton placeholder while the per-category tags (or the full
-          // tag list for search) load for the first time. `data === undefined`
-          // means React Query hasn't returned yet; once a category is cached
-          // or after an optimistic mutation we keep prior data and skip this
-          // branch so the panel doesn't flash empty on refetch.
-          const isLoadingTags = tagFilter
-            ? allTagsData === undefined && isFetchingAllTags
-            : activeCategoryTags === undefined && isFetchingCategoryTags;
-          if (isLoadingTags) {
-            if (activeViewMode === 'list') {
+            // Skeleton placeholder while the per-category tags (or the full
+            // tag list for search) load for the first time. `data === undefined`
+            // means React Query hasn't returned yet; once a category is cached
+            // or after an optimistic mutation we keep prior data and skip this
+            // branch so the panel doesn't flash empty on refetch.
+            const isLoadingTags = tagFilter
+              ? allTagsData === undefined && isFetchingAllTags
+              : activeCategoryTags === undefined && isFetchingCategoryTags;
+            if (isLoadingTags) {
+              if (activeViewMode === 'list') {
+                return (
+                  <div className="tag-list-view">
+                    <SkeletonTheme baseColor="#202020" highlightColor="#444">
+                      {Array.from({ length: 16 }).map((_, i) => (
+                        <Skeleton
+                          key={i}
+                          height={28}
+                          style={{ marginBottom: 4 }}
+                        />
+                      ))}
+                    </SkeletonTheme>
+                  </div>
+                );
+              }
               return (
-                <div className="tag-list-view">
+                <div className="tags">
                   <SkeletonTheme baseColor="#202020" highlightColor="#444">
-                    {Array.from({ length: 16 }).map((_, i) => (
-                      <Skeleton
-                        key={i}
-                        height={28}
-                        style={{ marginBottom: 4 }}
-                      />
+                    {Array.from({ length: 18 }).map((_, i) => (
+                      <Skeleton key={i} height={60} />
                     ))}
                   </SkeletonTheme>
                 </div>
               );
             }
-            return (
-              <div className="tags">
-                <SkeletonTheme baseColor="#202020" highlightColor="#444">
-                  {Array.from({ length: 18 }).map((_, i) => (
-                    <Skeleton key={i} height={60} />
-                  ))}
-                </SkeletonTheme>
-              </div>
-            );
-          }
-          if (activeViewMode === 'list') {
-            return (
-              <TagListView
-                tags={tags}
-                selectedTags={selectedTags}
-                isDisabled={isDisabled}
-                handleEditAction={setEditingTag}
-                disableReorder={disableReorder}
-              />
-            );
-          }
-          // Blended search view: when there are matches in the Suggested
-          // category, render non-Suggested results as cards on top and
-          // Suggested results as a compact list below. Both sections are
-          // virtualized — `<Tag>` triggers an IPC preview fetch on mount,
-          // so rendering all matches at once would saturate the IPC layer.
-          if (tagFilter) {
-            const suggestedTags = tags.filter(
-              (t: Concept) => t.category === 'Suggested'
-            );
-            if (suggestedTags.length > 0) {
-              const mainTags = tags.filter(
-                (t: Concept) => t.category !== 'Suggested'
-              );
+            if (activeViewMode === 'list') {
               return (
-                <div className="tags-blended">
-                  {mainTags.length > 0 && (
-                    <div className="tags-blended-cards">
-                      <VirtualizedTagGrid
-                        tags={mainTags}
+                <TagListView
+                  tags={tags}
+                  selectedTags={selectedTags}
+                  isDisabled={isDisabled}
+                  handleEditAction={setEditingTag}
+                  disableReorder={disableReorder}
+                />
+              );
+            }
+            // Blended search view: when there are matches in the Suggested
+            // category, render non-Suggested results as cards on top and
+            // Suggested results as a compact list below. Both sections are
+            // virtualized — `<Tag>` triggers an IPC preview fetch on mount,
+            // so rendering all matches at once would saturate the IPC layer.
+            if (tagFilter) {
+              const suggestedTags = tags.filter(
+                (t: Concept) => t.category === 'Suggested'
+              );
+              if (suggestedTags.length > 0) {
+                const mainTags = tags.filter(
+                  (t: Concept) => t.category !== 'Suggested'
+                );
+                return (
+                  <div className="tags-blended">
+                    {mainTags.length > 0 && (
+                      <div className="tags-blended-cards">
+                        <VirtualizedTagGrid
+                          tags={mainTags}
+                          selectedTags={selectedTags}
+                          isDisabled={isDisabled}
+                          handleEditAction={setEditingTag}
+                          disableReorder={disableReorder}
+                        />
+                      </div>
+                    )}
+                    <div className="suggested-section">
+                      <div className="suggested-heading">Suggested</div>
+                      <TagListView
+                        tags={suggestedTags}
                         selectedTags={selectedTags}
                         isDisabled={isDisabled}
                         handleEditAction={setEditingTag}
                         disableReorder={disableReorder}
                       />
                     </div>
-                  )}
-                  <div className="suggested-section">
-                    <div className="suggested-heading">Suggested</div>
-                    <TagListView
-                      tags={suggestedTags}
-                      selectedTags={selectedTags}
-                      isDisabled={isDisabled}
-                      handleEditAction={setEditingTag}
-                      disableReorder={disableReorder}
-                    />
                   </div>
-                </div>
-              );
+                );
+              }
             }
-          }
-          // Virtualize whenever searching (results can be large and each
-          // <Tag> mounts an IPC preview fetch), or when browsing a
-          // category that exceeds the static threshold.
-          if (tagFilter || tags.length > VIRTUALIZE_THRESHOLD) {
-            return (
-              <VirtualizedTagGrid
-                tags={tags}
-                selectedTags={selectedTags}
-                isDisabled={isDisabled}
-                handleEditAction={setEditingTag}
-                disableReorder={disableReorder}
-              />
-            );
-          }
-          return (
-            <div className={`tags`}>
-              {tags.map((tag: Concept) => (
-                <Tag
-                  isDisabled={isDisabled}
+            // Searching with zero tag matches: collapse the results pane
+            // entirely (return null) so the suggestions column can take the
+            // full width instead of sitting beside an empty grid.
+            if (tagFilter && tags.length === 0) {
+              return null;
+            }
+            // Virtualize whenever searching (results can be large and each
+            // <Tag> mounts an IPC preview fetch), or when browsing a
+            // category that exceeds the static threshold.
+            if (tagFilter || tags.length > VIRTUALIZE_THRESHOLD) {
+              return (
+                <VirtualizedTagGrid
                   tags={tags}
-                  tag={{
-                    label: tag.label,
-                    weight: tag.weight,
-                    category: tag.category,
-                  }}
-                  active={selectedTags.includes(tag.label)}
+                  selectedTags={selectedTags}
+                  isDisabled={isDisabled}
                   handleEditAction={setEditingTag}
                   disableReorder={disableReorder}
-                  key={tag.label}
                 />
-              ))}
+              );
+            }
+            return (
+              <div className={`tags`}>
+                {tags.map((tag: Concept) => (
+                  <Tag
+                    isDisabled={isDisabled}
+                    tags={tags}
+                    tag={{
+                      label: tag.label,
+                      weight: tag.weight,
+                      category: tag.category,
+                    }}
+                    active={selectedTags.includes(tag.label)}
+                    handleEditAction={setEditingTag}
+                    disableReorder={disableReorder}
+                    key={tag.label}
+                  />
+                ))}
+              </div>
+            );
+          })();
+
+          const showSuggestions = !!tagFilter;
+          const hasResults = resultsEl !== null;
+          const wrapperClass = [
+            'search-results',
+            hasResults ? 'has-results' : 'no-results',
+            showSuggestions ? 'has-suggestions' : '',
+          ]
+            .filter(Boolean)
+            .join(' ');
+
+          // The outer .search-results-container exists only to establish the
+          // container-query context: a container query can style a container's
+          // descendants but not the container element itself, so the
+          // stacked⇄two-column switch must live on the inner .search-results.
+          return (
+            <div className="search-results-container">
+              <div className={wrapperClass}>
+                {hasResults && (
+                  <div className="results-pane">{resultsEl}</div>
+                )}
+                {showSuggestions && (
+                  <div className="suggestions-pane">
+                    <SuggestionSections
+                      text={tagFilter}
+                      categories={categories ?? []}
+                      onAdd={(predicate) =>
+                        libraryService.send({
+                          type: 'ADD_PREDICATE',
+                          data: {
+                            predicate: {
+                              ...predicate,
+                              join: filteringMode === 'OR' ? 'OR' : 'AND',
+                            },
+                          },
+                        })
+                      }
+                    />
+                  </div>
+                )}
+              </div>
             </div>
           );
         })()}
-        {tagFilter ? (
-          <SuggestionSections
-            text={tagFilter}
-            categories={categories ?? []}
-            onAdd={(predicate) =>
-              libraryService.send({
-                type: 'ADD_PREDICATE',
-                data: {
-                  predicate: {
-                    ...predicate,
-                    join: filteringMode === 'OR' ? 'OR' : 'AND',
-                  },
-                },
-              })
-            }
-          />
-        ) : null}
       </div>
       {activeCategory && addingTag ? (
         <NewTagModal

--- a/src/renderer/components/taxonomy/taxonomy.tsx
+++ b/src/renderer/components/taxonomy/taxonomy.tsx
@@ -339,6 +339,11 @@ export default function Taxonomy() {
             disabled={isDisabled}
           />
         </div>
+        {/* Body row: fills the height left under the search bar so the inner
+            scroll areas size against that remaining height (not the whole
+            panel) and keep their full bottom padding — otherwise their bottoms
+            overhang the panel and the last row hides under the bottom overlay. */}
+        <div className="taxonomy-body">
         <div className="controls">
           <button
             data-tooltip-id="reset-query-tag"
@@ -607,6 +612,7 @@ export default function Taxonomy() {
             </div>
           );
         })()}
+        </div>
       </div>
       {activeCategory && addingTag ? (
         <NewTagModal

--- a/src/renderer/components/taxonomy/taxonomy.tsx
+++ b/src/renderer/components/taxonomy/taxonomy.tsx
@@ -388,6 +388,7 @@ export default function Taxonomy() {
                       type: 'tag',
                       value: top.label,
                       exclude: false,
+                      join: filteringMode === 'OR' ? 'OR' : 'AND',
                     },
                   },
                 });
@@ -406,6 +407,12 @@ export default function Taxonomy() {
               libraryService.send({
                 type: 'TOGGLE_EXCLUDE',
                 data: { key },
+              })
+            }
+            onSetPredicateJoin={(key, join) =>
+              libraryService.send({
+                type: 'SET_PREDICATE_JOIN',
+                data: { key, join },
               })
             }
             onClearAll={() => {
@@ -634,7 +641,15 @@ export default function Taxonomy() {
             text={tagFilter}
             categories={categories ?? []}
             onAdd={(predicate) =>
-              libraryService.send({ type: 'ADD_PREDICATE', data: { predicate } })
+              libraryService.send({
+                type: 'ADD_PREDICATE',
+                data: {
+                  predicate: {
+                    ...predicate,
+                    join: filteringMode === 'OR' ? 'OR' : 'AND',
+                  },
+                },
+              })
             }
           />
         ) : null}

--- a/src/renderer/components/taxonomy/taxonomy.tsx
+++ b/src/renderer/components/taxonomy/taxonomy.tsx
@@ -284,6 +284,13 @@ export default function Taxonomy() {
             query={query}
             textValue={tagFilterInput}
             onTextChange={setTagFilterInput}
+            filteringMode={filteringMode}
+            onCycleFilterMode={() =>
+              libraryService.send({
+                type: 'CHANGE_SETTING',
+                data: { filteringMode: getNextFilterMode(filteringMode) },
+              })
+            }
             onFocus={() => setSearchFocused(true)}
             onSubmitText={() => {
               // Commit the top tag suggestion as a predicate, then clear text.

--- a/src/renderer/components/taxonomy/taxonomy.tsx
+++ b/src/renderer/components/taxonomy/taxonomy.tsx
@@ -22,6 +22,7 @@ import NewTagModal from './new-tag-modal';
 import NewCategoryModal from './new-category-modal';
 import './taxonomy.css';
 import Category from './category';
+import SuggestionSections from './suggestion-sections';
 import { invoke } from '../../platform';
 import QueryInput from '../query-input/QueryInput';
 
@@ -628,6 +629,15 @@ export default function Taxonomy() {
             </div>
           );
         })()}
+        {tagFilter ? (
+          <SuggestionSections
+            text={tagFilter}
+            categories={categories ?? []}
+            onAdd={(predicate) =>
+              libraryService.send({ type: 'ADD_PREDICATE', data: { predicate } })
+            }
+          />
+        ) : null}
       </div>
       {activeCategory && addingTag ? (
         <NewTagModal

--- a/src/renderer/components/taxonomy/taxonomy.tsx
+++ b/src/renderer/components/taxonomy/taxonomy.tsx
@@ -122,14 +122,21 @@ export default function Taxonomy() {
   }, [textFilter]);
 
   // Two-tier search state: tagFilterInput updates on every keystroke so the
-  // input feels responsive; tagFilter is the debounced value that drives the
-  // (potentially expensive) filter+sort over many tags.
+  // input feels responsive; tagFilter is the debounced value dispatched to the
+  // search worker. The actual fuzzy match runs off-thread (see the worker
+  // setup below), so the debounce only needs to coalesce bursts of keystrokes
+  // rather than guard the main thread — hence a short 150ms window.
   const [tagFilterInput, setTagFilterInput] = useState<string>('');
   const [tagFilter, setTagFilter] = useState<string>('');
+  // Set once the search input has been focused. Used to warm the full-tag
+  // fetch (and worker index) before the first keystroke so the initial search
+  // isn't stalled waiting on the network. Stays true for the session — with
+  // staleTime: Infinity the data is fetched at most once.
+  const [searchFocused, setSearchFocused] = useState<boolean>(false);
   const debouncedSetTagFilter = useRef(
     debounce((value: string) => {
       setTagFilter(value);
-    }, 300)
+    }, 150)
   );
   useEffect(() => {
     debouncedSetTagFilter.current(tagFilterInput);
@@ -190,14 +197,15 @@ export default function Taxonomy() {
       { enabled: !!activeCategory, staleTime: Infinity }
     );
 
-  // Triggered on the first keystroke (tagFilterInput, pre-debounce) so the
-  // network request overlaps with the 300ms debounce window — by the time
-  // tagFilter actually fires Fuse, the data is usually already in cache.
+  // Warmed as soon as the search input gains focus (or, as a fallback, on the
+  // first keystroke) so the fetch + worker indexing overlap with the user
+  // composing their query — by the time they type, the data is usually already
+  // cached and indexed, so the initial search isn't stalled on the network.
   const { data: allTagsData, isFetching: isFetchingAllTags } = useQuery<
     Concept[],
     Error
   >(['taxonomy', 'all-tags', initSessionId], loadAllTags, {
-    enabled: !!tagFilterInput,
+    enabled: searchFocused || !!tagFilterInput,
     staleTime: Infinity,
   });
 
@@ -264,40 +272,102 @@ export default function Taxonomy() {
     );
   }, [allTagsData]);
 
-  const fuse = useMemo(
-    () =>
-      new Fuse(allTags, {
-        // Search the tag's own label and its category name. The label
-        // weight is higher so a direct label match always ranks above a
-        // hit that only matched via the category name (e.g. searching
-        // "Subject" returns every Subject tag, but a Subject tag whose
-        // own label also contains "Subject" lands at the top).
-        keys: [
-          { name: 'label', weight: 2 },
-          { name: 'category', weight: 1 },
-        ],
-        threshold: 0.4,
-        ignoreLocation: true,
-        minMatchCharLength: 1,
-      }),
-    [allTags]
+  // Async tag search. Indexing and fuzzy matching run in a Web Worker so a
+  // large library (tens of thousands of tags) never blocks the input. Each
+  // request carries an id (searchSeq); responses that aren't the latest are
+  // dropped so a slow earlier search can't clobber newer results.
+  const workerRef = useRef<Worker | null>(null);
+  const searchSeq = useRef(0);
+  const [searchResults, setSearchResults] = useState<Concept[]>([]);
+  // Optimistically assume worker support; flip to false if construction fails
+  // (e.g. jsdom in tests) so the synchronous fallback below takes over.
+  const [workerReady, setWorkerReady] = useState<boolean>(
+    typeof Worker !== 'undefined'
   );
+
+  useEffect(() => {
+    if (typeof Worker === 'undefined') {
+      setWorkerReady(false);
+      return undefined;
+    }
+    let worker: Worker;
+    try {
+      worker = new Worker(new URL('./tag-search.worker.ts', import.meta.url));
+    } catch {
+      setWorkerReady(false);
+      return undefined;
+    }
+    worker.onmessage = (e: MessageEvent) => {
+      const msg = e.data;
+      if (msg?.type === 'result' && msg.id === searchSeq.current) {
+        setSearchResults(msg.items as Concept[]);
+      }
+    };
+    workerRef.current = worker;
+    setWorkerReady(true);
+    return () => {
+      worker.terminate();
+      workerRef.current = null;
+    };
+  }, []);
+
+  // Keep the worker's index in sync with the loaded tag set. The worker
+  // re-runs the outstanding query after re-indexing, so results refresh
+  // automatically once data first arrives or after a tag mutation.
+  useEffect(() => {
+    workerRef.current?.postMessage({ type: 'index', tags: allTags });
+  }, [allTags]);
+
+  // Synchronous Fuse fallback — only built/used when no worker is available.
+  // Keep these options in sync with tag-search.worker.ts.
+  const fallbackFuse = useMemo(() => {
+    if (workerReady) return null;
+    return new Fuse(allTags, {
+      keys: [
+        { name: 'label', weight: 2 },
+        { name: 'category', weight: 1 },
+      ],
+      threshold: 0.4,
+      ignoreLocation: true,
+      minMatchCharLength: 1,
+    });
+  }, [allTags, workerReady]);
+
+  // Dispatch the debounced query. With a worker the match happens off-thread
+  // and arrives via onmessage; without one we fall back to a synchronous
+  // search. Bumping searchSeq invalidates any in-flight worker response.
+  useEffect(() => {
+    const id = (searchSeq.current += 1);
+    if (!tagFilter) {
+      setSearchResults([]);
+    }
+    if (workerRef.current) {
+      workerRef.current.postMessage({
+        type: 'search',
+        id,
+        query: tagFilter,
+        limit: MAX_SEARCH_RESULTS,
+      });
+    } else if (fallbackFuse && tagFilter) {
+      setSearchResults(
+        fallbackFuse
+          .search(tagFilter, { limit: MAX_SEARCH_RESULTS })
+          .map((r) => r.item)
+      );
+    }
+  }, [tagFilter, fallbackFuse]);
 
   const tags = useMemo(() => {
     if (tagFilter) {
-      // Fuzzy match across all categories. Fuse returns results pre-sorted
-      // by relevance (best match first). Cap at MAX_SEARCH_RESULTS so a
-      // pathological query can't render thousands of cards at once. When
-      // allTagsData hasn't loaded yet (first search), the Fuse index is
-      // empty and we render no results until it arrives.
-      return fuse
-        .search(tagFilter, { limit: MAX_SEARCH_RESULTS })
-        .map((r) => r.item);
+      // Worker-ranked, pre-capped matches across all categories. Briefly empty
+      // (or showing the prior query's results) until the worker responds —
+      // acceptable for an async search and imperceptible at this debounce.
+      return searchResults;
     }
     return (activeCategoryTags ?? [])
       .slice()
       .sort((a, b) => a.weight - b.weight);
-  }, [tagFilter, activeCategoryTags, fuse]);
+  }, [tagFilter, searchResults, activeCategoryTags]);
 
   if (!categories || state.matches('loadingDB') || state.matches('selectingDB')) {
     return (
@@ -338,6 +408,7 @@ export default function Taxonomy() {
               type="text"
               placeholder="Search Tags"
               value={tagFilterInput}
+              onFocus={() => setSearchFocused(true)}
               onKeyDown={(e) => {
                 e.stopPropagation();
               }}

--- a/src/renderer/hooks/useFileDrop.ts
+++ b/src/renderer/hooks/useFileDrop.ts
@@ -103,8 +103,7 @@ export default function useFileDrop() {
       const snapshot = libraryService.getSnapshot();
       const isLoaded =
         snapshot.matches({ library: 'loadedFromFS' }) ||
-        snapshot.matches({ library: 'loadedFromDB' }) ||
-        snapshot.matches({ library: 'loadedFromSearch' });
+        snapshot.matches({ library: 'loadedFromDB' });
       if (!isLoaded) return;
 
       const nativeFiles = item.files;

--- a/src/renderer/hooks/useSearchHistory.ts
+++ b/src/renderer/hooks/useSearchHistory.ts
@@ -4,7 +4,19 @@ import { sessionStore } from '../platform';
 const STORAGE_KEY = 'searchHistory';
 const MAX_HISTORY = 100;
 
+// Module-level shared state. The history is a single logical list, but it's
+// consumed by more than one hook instance at a time (e.g. the command palette
+// renders a QueryInput *and* records selections from its results surface). A
+// listener registry keeps every mounted instance in sync, so a save made from
+// one instance is immediately reflected in another instance's dropdown.
 let historyCache: string[] | null = null;
+const listeners = new Set<(history: string[]) => void>();
+
+function emit(next: string[]) {
+  historyCache = next;
+  listeners.forEach((listener) => listener(next));
+  sessionStore.set(STORAGE_KEY, next).catch(() => {});
+}
 
 async function loadHistory(): Promise<string[]> {
   if (historyCache !== null) return historyCache;
@@ -17,40 +29,38 @@ async function loadHistory(): Promise<string[]> {
   return historyCache;
 }
 
-function persistHistory(history: string[]) {
-  historyCache = history;
-  sessionStore.set(STORAGE_KEY, history).catch(() => {});
-}
-
 export function useSearchHistory() {
   const [history, setHistory] = useState<string[]>(historyCache ?? []);
 
   useEffect(() => {
-    loadHistory().then(setHistory);
+    const listener = (next: string[]) => setHistory(next);
+    listeners.add(listener);
+    // Pull the current shared value (cached or freshly loaded) into this
+    // instance. Subsequent mutations arrive via the listener.
+    loadHistory().then((loaded) => setHistory(loaded));
+    return () => {
+      listeners.delete(listener);
+    };
   }, []);
 
   const addSearch = useCallback((query: string) => {
     const trimmed = query.trim();
     if (!trimmed) return;
-    setHistory((prev) => {
-      const filtered = prev.filter((item) => item !== trimmed);
-      const next = [trimmed, ...filtered].slice(0, MAX_HISTORY);
-      persistHistory(next);
-      return next;
-    });
+    const prev = historyCache ?? [];
+    const next = [trimmed, ...prev.filter((item) => item !== trimmed)].slice(
+      0,
+      MAX_HISTORY
+    );
+    emit(next);
   }, []);
 
   const removeSearch = useCallback((query: string) => {
-    setHistory((prev) => {
-      const next = prev.filter((item) => item !== query);
-      persistHistory(next);
-      return next;
-    });
+    const prev = historyCache ?? [];
+    emit(prev.filter((item) => item !== query));
   }, []);
 
   const clearAll = useCallback(() => {
-    persistHistory([]);
-    setHistory([]);
+    emit([]);
   }, []);
 
   return { history, addSearch, removeSearch, clearAll };

--- a/src/renderer/hooks/useSessionStore.ts
+++ b/src/renderer/hooks/useSessionStore.ts
@@ -30,6 +30,9 @@ export interface SessionQueryData {
   dbQuery: {
     tags: string[];
   };
+  // Unified structured query (flat predicate list). Optional for backward
+  // compatibility with snapshots written before the unified query existed.
+  query?: import('../query/types').Query;
   mostRecentTag: string;
   mostRecentCategory: string;
   textFilter: string;
@@ -45,6 +48,8 @@ export interface SessionPreviousData {
   previousStateType?: LibraryStateType | null;
   previousTextFilter?: string;
   previousDbQuery?: { tags: string[] };
+  // Previous unified structured query, mirrored alongside previousDbQuery.
+  previousQuery?: import('../query/types').Query;
   // Path the library was loaded for, so back-restoration keeps
   // initialFile coherent with the restored library snapshot.
   previousInitialFile?: string;

--- a/src/renderer/hooks/useSessionStore.ts
+++ b/src/renderer/hooks/useSessionStore.ts
@@ -39,7 +39,7 @@ export interface SessionQueryData {
 }
 
 // State type for tracking which mode the library was loaded from
-type LibraryStateType = 'fs' | 'db' | 'search';
+type LibraryStateType = 'fs' | 'db';
 
 export interface SessionPreviousData {
   previousLibrary: Item[];

--- a/src/renderer/hooks/useSessionStore.ts
+++ b/src/renderer/hooks/useSessionStore.ts
@@ -172,6 +172,17 @@ export function hasPersistedTags(): boolean {
 }
 
 /**
+ * Check if the session has a persisted unified query with at least one
+ * predicate. Unlike hasPersistedTags, this recognises non-tag filters
+ * (path / category / description / hash) so they are restored as a filtered
+ * (DB) view at boot instead of being dropped as "no filter".
+ */
+export function hasPersistedQuery(): boolean {
+  const data = cache.query;
+  return !!(data && data.query && data.query.predicates.length > 0);
+}
+
+/**
  * Set a value in the session store (debounced async write)
  */
 export function setSessionValue<K extends SessionKey>(

--- a/src/renderer/hooks/useTagSearch.ts
+++ b/src/renderer/hooks/useTagSearch.ts
@@ -1,0 +1,162 @@
+// useTagSearch — reusable, off-thread tag type-ahead.
+//
+// Encapsulates the worker + Fuse-fallback + debounce tag search that lives
+// inline in components/taxonomy/taxonomy.tsx. Lifted faithfully so the command
+// palette can reuse it without depending on the taxonomy panel. The taxonomy
+// panel intentionally keeps its own copy (to avoid regressions); a duplicate
+// worker instance per consumer is fine.
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useSelector } from '@xstate/react';
+import { useQuery } from '@tanstack/react-query';
+import { debounce } from 'lodash';
+import Fuse from 'fuse.js';
+import { GlobalStateContext } from '../state';
+import { invoke } from '../platform';
+
+export interface TagConcept {
+  label: string;
+  category: string;
+  weight: number;
+  description?: string;
+}
+
+// Mirrors taxonomy.tsx: each rendered result can trigger downstream IPC work,
+// so we cap the match list even though Fuse ranks across the full set.
+const MAX_SEARCH_RESULTS = 200;
+
+async function loadAllTags(): Promise<TagConcept[]> {
+  const result = await invoke('load-all-tags', []);
+  return (result as TagConcept[]) ?? [];
+}
+
+/**
+ * Off-thread fuzzy tag search.
+ *
+ * @param text    The raw (un-debounced) search text.
+ * @param enabled Gates the all-tags fetch + search so it only runs while the
+ *                consuming surface is active.
+ */
+export function useTagSearch(
+  text: string,
+  enabled: boolean
+): { results: TagConcept[] } {
+  const { libraryService } = useContext(GlobalStateContext);
+  const initSessionId = useSelector(
+    libraryService,
+    (state) => state.context.initSessionId
+  );
+
+  // Debounce the raw text into the value actually dispatched to the worker.
+  const [debouncedText, setDebouncedText] = useState<string>('');
+  const debouncedSet = useRef(
+    debounce((value: string) => setDebouncedText(value), 150)
+  );
+  useEffect(() => {
+    debouncedSet.current(text);
+  }, [text]);
+  useEffect(() => {
+    const d = debouncedSet.current;
+    return () => d.cancel();
+  }, []);
+
+  // Lazy full-tag fetch — same React Query key + loader as taxonomy.tsx so the
+  // two consumers share a single cached fetch per session.
+  const { data: allTagsData } = useQuery<TagConcept[], Error>(
+    ['taxonomy', 'all-tags', initSessionId],
+    loadAllTags,
+    { enabled, staleTime: Infinity }
+  );
+
+  // Defensive filter: drop label-less tags; Fuse and the row renderers assume a
+  // non-empty string and would otherwise throw.
+  const allTags = useMemo(() => {
+    if (!allTagsData) return [] as TagConcept[];
+    return allTagsData.filter(
+      (t) => t && typeof t.label === 'string' && t.label.length > 0
+    );
+  }, [allTagsData]);
+
+  const workerRef = useRef<Worker | null>(null);
+  const searchSeq = useRef(0);
+  const [results, setResults] = useState<TagConcept[]>([]);
+  // Optimistically assume worker support; flip to false if construction fails
+  // (e.g. jsdom under tests) so the synchronous fallback takes over.
+  const [workerReady, setWorkerReady] = useState<boolean>(
+    typeof Worker !== 'undefined'
+  );
+
+  useEffect(() => {
+    if (typeof Worker === 'undefined') {
+      setWorkerReady(false);
+      return undefined;
+    }
+    let worker: Worker;
+    try {
+      worker = new Worker(
+        new URL('../components/taxonomy/tag-search.worker.ts', import.meta.url)
+      );
+    } catch {
+      setWorkerReady(false);
+      return undefined;
+    }
+    worker.onmessage = (e: MessageEvent) => {
+      const msg = e.data;
+      if (msg?.type === 'result' && msg.id === searchSeq.current) {
+        setResults(msg.items as TagConcept[]);
+      }
+    };
+    workerRef.current = worker;
+    setWorkerReady(true);
+    return () => {
+      worker.terminate();
+      workerRef.current = null;
+    };
+  }, []);
+
+  // Keep the worker index synced with the loaded tag set. The worker re-runs
+  // the outstanding query after re-indexing, so results refresh automatically.
+  useEffect(() => {
+    workerRef.current?.postMessage({ type: 'index', tags: allTags });
+  }, [allTags]);
+
+  // Synchronous Fuse fallback — only built when no worker is available.
+  // Keep these options in sync with tag-search.worker.ts.
+  const fallbackFuse = useMemo(() => {
+    if (workerReady) return null;
+    return new Fuse(allTags, {
+      keys: [
+        { name: 'label', weight: 2 },
+        { name: 'category', weight: 1 },
+      ],
+      threshold: 0.4,
+      ignoreLocation: true,
+      minMatchCharLength: 1,
+    });
+  }, [allTags, workerReady]);
+
+  useEffect(() => {
+    const id = (searchSeq.current += 1);
+    const activeQuery = enabled ? debouncedText : '';
+    if (!activeQuery) {
+      setResults([]);
+    }
+    if (workerRef.current) {
+      workerRef.current.postMessage({
+        type: 'search',
+        id,
+        query: activeQuery,
+        limit: MAX_SEARCH_RESULTS,
+      });
+    } else if (fallbackFuse && activeQuery) {
+      setResults(
+        fallbackFuse
+          .search(activeQuery, { limit: MAX_SEARCH_RESULTS })
+          .map((r) => r.item)
+      );
+    }
+  }, [debouncedText, enabled, fallbackFuse]);
+
+  return { results };
+}
+
+export default useTagSearch;

--- a/src/renderer/hooks/useTagSearch.ts
+++ b/src/renderer/hooks/useTagSearch.ts
@@ -5,7 +5,7 @@
 // through the module-level singleton in ../search/tag-search-service, so the
 // whole app shares ONE worker + ONE index (warmed at startup by
 // useWarmTagSearch). This keeps the first search from either surface instant.
-import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import { useSelector } from '@xstate/react';
 import { useQuery } from '@tanstack/react-query';
 import { debounce } from 'lodash';
@@ -16,6 +16,7 @@ import {
   searchTags,
   type TagConcept,
 } from '../search/tag-search-service';
+import { SEARCH_DEBOUNCE_MS } from '../search/search-config';
 
 export type { TagConcept } from '../search/tag-search-service';
 
@@ -45,10 +46,10 @@ export function useTagSearch(
     (state) => state.context.initSessionId
   );
 
-  // Debounce the raw text 150ms into the value actually dispatched to search.
+  // Debounce the raw text into the value actually dispatched to search.
   const [debouncedText, setDebouncedText] = useState<string>('');
   const debouncedSet = useRef(
-    debounce((value: string) => setDebouncedText(value), 150)
+    debounce((value: string) => setDebouncedText(value), SEARCH_DEBOUNCE_MS)
   );
   useEffect(() => {
     debouncedSet.current(text);
@@ -66,19 +67,14 @@ export function useTagSearch(
     { enabled, staleTime: Infinity }
   );
 
-  // Defensive filter: drop label-less tags; Fuse and the row renderers assume a
-  // non-empty string and would otherwise throw.
-  const allTags = useMemo(() => {
-    if (!allTagsData) return [] as TagConcept[];
-    return allTagsData.filter(
-      (t) => t && typeof t.label === 'string' && t.label.length > 0
-    );
-  }, [allTagsData]);
-
-  // Keep the shared index in sync with the loaded tag set (idempotent by ref).
+  // Keep the shared index in sync with the loaded tag set. Index off the RAW
+  // React Query array (not a locally-filtered copy): every consumer reads the
+  // same cache entry, so this shared reference lets indexTags dedupe to a single
+  // worker clone instead of re-cloning the whole library on this surface's first
+  // search. The defensive label filter now lives inside indexTags.
   useEffect(() => {
-    indexTags(allTags);
-  }, [allTags]);
+    if (allTagsData) indexTags(allTagsData);
+  }, [allTagsData]);
 
   const [results, setResults] = useState<TagConcept[]>([]);
 
@@ -100,7 +96,7 @@ export function useTagSearch(
       MAX_SEARCH_RESULTS,
       setResultsSafe.current
     );
-  }, [debouncedText, enabled, allTags]);
+  }, [debouncedText, enabled, allTagsData]);
 
   return { results };
 }

--- a/src/renderer/hooks/useTagSearch.ts
+++ b/src/renderer/hooks/useTagSearch.ts
@@ -1,27 +1,26 @@
-// useTagSearch — reusable, off-thread tag type-ahead.
+// useTagSearch — reusable tag type-ahead over the SHARED, pre-warmed index.
 //
-// Encapsulates the worker + Fuse-fallback + debounce tag search that lives
-// inline in components/taxonomy/taxonomy.tsx. Lifted faithfully so the command
-// palette can reuse it without depending on the taxonomy panel. The taxonomy
-// panel intentionally keeps its own copy (to avoid regressions); a duplicate
-// worker instance per consumer is fine.
+// Both the taxonomy sidebar and the command palette consume this hook. It no
+// longer owns a worker or Fuse instance: all indexing + matching is routed
+// through the module-level singleton in ../search/tag-search-service, so the
+// whole app shares ONE worker + ONE index (warmed at startup by
+// useWarmTagSearch). This keeps the first search from either surface instant.
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from '@xstate/react';
 import { useQuery } from '@tanstack/react-query';
 import { debounce } from 'lodash';
-import Fuse from 'fuse.js';
 import { GlobalStateContext } from '../state';
 import { invoke } from '../platform';
+import {
+  indexTags,
+  searchTags,
+  type TagConcept,
+} from '../search/tag-search-service';
 
-export interface TagConcept {
-  label: string;
-  category: string;
-  weight: number;
-  description?: string;
-}
+export type { TagConcept } from '../search/tag-search-service';
 
-// Mirrors taxonomy.tsx: each rendered result can trigger downstream IPC work,
-// so we cap the match list even though Fuse ranks across the full set.
+// Mirrors the historical cap: each rendered result can trigger downstream IPC
+// work, so we cap the match list even though Fuse ranks across the full set.
 const MAX_SEARCH_RESULTS = 200;
 
 async function loadAllTags(): Promise<TagConcept[]> {
@@ -30,11 +29,11 @@ async function loadAllTags(): Promise<TagConcept[]> {
 }
 
 /**
- * Off-thread fuzzy tag search.
+ * Off-thread fuzzy tag search backed by the shared singleton index.
  *
  * @param text    The raw (un-debounced) search text.
- * @param enabled Gates the all-tags fetch + search so it only runs while the
- *                consuming surface is active.
+ * @param enabled Gates the active search so it only runs while the consuming
+ *                surface wants results.
  */
 export function useTagSearch(
   text: string,
@@ -46,7 +45,7 @@ export function useTagSearch(
     (state) => state.context.initSessionId
   );
 
-  // Debounce the raw text into the value actually dispatched to the worker.
+  // Debounce the raw text 150ms into the value actually dispatched to search.
   const [debouncedText, setDebouncedText] = useState<string>('');
   const debouncedSet = useRef(
     debounce((value: string) => setDebouncedText(value), 150)
@@ -59,8 +58,8 @@ export function useTagSearch(
     return () => d.cancel();
   }, []);
 
-  // Lazy full-tag fetch — same React Query key + loader as taxonomy.tsx so the
-  // two consumers share a single cached fetch per session.
+  // Full-tag fetch — same React Query key + loader as the warmer and taxonomy
+  // so all consumers share a single cached fetch per session.
   const { data: allTagsData } = useQuery<TagConcept[], Error>(
     ['taxonomy', 'all-tags', initSessionId],
     loadAllTags,
@@ -76,85 +75,32 @@ export function useTagSearch(
     );
   }, [allTagsData]);
 
-  const workerRef = useRef<Worker | null>(null);
-  const searchSeq = useRef(0);
-  const [results, setResults] = useState<TagConcept[]>([]);
-  // Optimistically assume worker support; flip to false if construction fails
-  // (e.g. jsdom under tests) so the synchronous fallback takes over.
-  const [workerReady, setWorkerReady] = useState<boolean>(
-    typeof Worker !== 'undefined'
-  );
-
+  // Keep the shared index in sync with the loaded tag set (idempotent by ref).
   useEffect(() => {
-    if (typeof Worker === 'undefined') {
-      setWorkerReady(false);
-      return undefined;
-    }
-    let worker: Worker;
-    try {
-      worker = new Worker(
-        new URL('../components/taxonomy/tag-search.worker.ts', import.meta.url)
-      );
-    } catch {
-      setWorkerReady(false);
-      return undefined;
-    }
-    worker.onmessage = (e: MessageEvent) => {
-      const msg = e.data;
-      if (msg?.type === 'result' && msg.id === searchSeq.current) {
-        setResults(msg.items as TagConcept[]);
-      }
-    };
-    workerRef.current = worker;
-    setWorkerReady(true);
-    return () => {
-      worker.terminate();
-      workerRef.current = null;
-    };
-  }, []);
-
-  // Keep the worker index synced with the loaded tag set. The worker re-runs
-  // the outstanding query after re-indexing, so results refresh automatically.
-  useEffect(() => {
-    workerRef.current?.postMessage({ type: 'index', tags: allTags });
+    indexTags(allTags);
   }, [allTags]);
 
-  // Synchronous Fuse fallback — only built when no worker is available.
-  // Keep these options in sync with tag-search.worker.ts.
-  const fallbackFuse = useMemo(() => {
-    if (workerReady) return null;
-    return new Fuse(allTags, {
-      keys: [
-        { name: 'label', weight: 2 },
-        { name: 'category', weight: 1 },
-      ],
-      threshold: 0.4,
-      ignoreLocation: true,
-      minMatchCharLength: 1,
-    });
-  }, [allTags, workerReady]);
+  const [results, setResults] = useState<TagConcept[]>([]);
+
+  // Stable callback that guards against late results after unmount.
+  const aliveRef = useRef(true);
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+  const setResultsSafe = useRef((items: TagConcept[]) => {
+    if (aliveRef.current) setResults(items);
+  });
 
   useEffect(() => {
-    const id = (searchSeq.current += 1);
-    const activeQuery = enabled ? debouncedText : '';
-    if (!activeQuery) {
-      setResults([]);
-    }
-    if (workerRef.current) {
-      workerRef.current.postMessage({
-        type: 'search',
-        id,
-        query: activeQuery,
-        limit: MAX_SEARCH_RESULTS,
-      });
-    } else if (fallbackFuse && activeQuery) {
-      setResults(
-        fallbackFuse
-          .search(activeQuery, { limit: MAX_SEARCH_RESULTS })
-          .map((r) => r.item)
-      );
-    }
-  }, [debouncedText, enabled, fallbackFuse]);
+    searchTags(
+      enabled ? debouncedText : '',
+      MAX_SEARCH_RESULTS,
+      setResultsSafe.current
+    );
+  }, [debouncedText, enabled, allTags]);
 
   return { results };
 }

--- a/src/renderer/hooks/useWarmTagSearch.ts
+++ b/src/renderer/hooks/useWarmTagSearch.ts
@@ -24,12 +24,16 @@ export function useWarmTagSearch(): void {
   );
 
   // Same key + loader as useTagSearch / taxonomy so this primes the shared
-  // cache. enabled: true kicks the fetch off at startup; staleTime: Infinity
-  // means it runs at most once per session (re-keyed on initSessionId).
+  // cache. Gated on initSessionId (assigned only once the machine reaches its
+  // post-DB `init` state) so the fetch never races ahead of the load-db handler
+  // registration — firing earlier just yields a guaranteed "No handler
+  // registered for 'load-all-tags'" rejection on every launch. staleTime:
+  // Infinity means it then runs at most once per session (re-keyed on
+  // initSessionId).
   const { data: allTagsData } = useQuery<TagConcept[], Error>(
     ['taxonomy', 'all-tags', initSessionId],
     loadAllTags,
-    { enabled: true, staleTime: Infinity }
+    { enabled: !!initSessionId, staleTime: Infinity }
   );
 
   // Build the shared index ahead of first use, off the RAW React Query array so

--- a/src/renderer/hooks/useWarmTagSearch.ts
+++ b/src/renderer/hooks/useWarmTagSearch.ts
@@ -4,7 +4,7 @@
 // full all-tags list is fetched eagerly and pushed into the shared singleton
 // index. By the time the user opens the taxonomy sidebar or the command
 // palette, the index is already warm and the first search is instant.
-import { useContext, useEffect, useMemo } from 'react';
+import { useContext, useEffect } from 'react';
 import { useSelector } from '@xstate/react';
 import { useQuery } from '@tanstack/react-query';
 import { GlobalStateContext } from '../state';
@@ -32,17 +32,14 @@ export function useWarmTagSearch(): void {
     { enabled: true, staleTime: Infinity }
   );
 
-  const allTags = useMemo(() => {
-    if (!allTagsData) return [] as TagConcept[];
-    return allTagsData.filter(
-      (t) => t && typeof t.label === 'string' && t.label.length > 0
-    );
-  }, [allTagsData]);
-
-  // Build the shared index ahead of first use.
+  // Build the shared index ahead of first use, off the RAW React Query array so
+  // the same reference is shared with every other consumer (taxonomy, palette).
+  // That shared reference is what lets indexTags clone the library to the worker
+  // exactly once — here at startup — instead of again on each surface's first
+  // search. The defensive label filter lives inside indexTags.
   useEffect(() => {
-    indexTags(allTags);
-  }, [allTags]);
+    if (allTagsData) indexTags(allTagsData);
+  }, [allTagsData]);
 }
 
 export default useWarmTagSearch;

--- a/src/renderer/hooks/useWarmTagSearch.ts
+++ b/src/renderer/hooks/useWarmTagSearch.ts
@@ -1,0 +1,48 @@
+// useWarmTagSearch — builds the shared tag-search index at app startup.
+//
+// Mounted once near the app root (after the library DB is available) so the
+// full all-tags list is fetched eagerly and pushed into the shared singleton
+// index. By the time the user opens the taxonomy sidebar or the command
+// palette, the index is already warm and the first search is instant.
+import { useContext, useEffect, useMemo } from 'react';
+import { useSelector } from '@xstate/react';
+import { useQuery } from '@tanstack/react-query';
+import { GlobalStateContext } from '../state';
+import { invoke } from '../platform';
+import { indexTags, type TagConcept } from '../search/tag-search-service';
+
+async function loadAllTags(): Promise<TagConcept[]> {
+  const result = await invoke('load-all-tags', []);
+  return (result as TagConcept[]) ?? [];
+}
+
+export function useWarmTagSearch(): void {
+  const { libraryService } = useContext(GlobalStateContext);
+  const initSessionId = useSelector(
+    libraryService,
+    (state) => state.context.initSessionId
+  );
+
+  // Same key + loader as useTagSearch / taxonomy so this primes the shared
+  // cache. enabled: true kicks the fetch off at startup; staleTime: Infinity
+  // means it runs at most once per session (re-keyed on initSessionId).
+  const { data: allTagsData } = useQuery<TagConcept[], Error>(
+    ['taxonomy', 'all-tags', initSessionId],
+    loadAllTags,
+    { enabled: true, staleTime: Infinity }
+  );
+
+  const allTags = useMemo(() => {
+    if (!allTagsData) return [] as TagConcept[];
+    return allTagsData.filter(
+      (t) => t && typeof t.label === 'string' && t.label.length > 0
+    );
+  }, [allTagsData]);
+
+  // Build the shared index ahead of first use.
+  useEffect(() => {
+    indexTags(allTags);
+  }, [allTags]);
+}
+
+export default useWarmTagSearch;

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -2,6 +2,25 @@ import { createRoot } from 'react-dom/client';
 import invariant from 'tiny-invariant';
 import { GlobalStateProvider } from './state';
 import App from './App';
+import { logEvent } from './platform';
+
+// Capture renderer crashes/unhandled rejections to the app log file so a
+// frozen or blank UI in the field leaves a diagnosable trail.
+window.addEventListener('error', (e) => {
+  logEvent({
+    scope: 'window.onerror',
+    message: e.message || 'window error',
+    data: { filename: e.filename, lineno: e.lineno, colno: e.colno },
+    error: e.error,
+  });
+});
+window.addEventListener('unhandledrejection', (e) => {
+  logEvent({
+    scope: 'unhandledrejection',
+    message: 'Unhandled promise rejection in renderer',
+    error: (e as PromiseRejectionEvent).reason,
+  });
+});
 
 const container = document.getElementById('root');
 invariant(container, 'root element not found');

--- a/src/renderer/platform.ts
+++ b/src/renderer/platform.ts
@@ -363,6 +363,11 @@ export let loadMediaByDescriptionSearch: (
   filteringMode?: string
 ) => Promise<any>;
 
+export let loadMediaByQuery: (
+  predicates: import('./query/types').Predicate[],
+  mode?: string
+) => Promise<any>;
+
 export let fetchMediaPreview: (
   path: string,
   cache: ImageCache,
@@ -428,6 +433,7 @@ if (isElectron) {
   transcript = window.electron.transcript;
   loadMediaFromDB = window.electron.loadMediaFromDB as any;
   loadMediaByDescriptionSearch = window.electron.loadMediaByDescriptionSearch;
+  loadMediaByQuery = window.electron.loadMediaByQuery as any;
   fetchMediaPreview = window.electron.fetchMediaPreview;
   fetchTagPreview = window.electron.fetchTagPreview;
   fetchTagCount = window.electron.fetchTagCount;
@@ -635,6 +641,11 @@ if (isElectron) {
 
   loadMediaByDescriptionSearch = async (description, tags, filteringMode) => {
     const library = await jsonPost('/api/media/search', { description, tags, filteringMode });
+    return { library: library || [], cursor: 0 };
+  };
+
+  loadMediaByQuery = async (predicates, mode = 'AND') => {
+    const library = await jsonPost('/api/media/query', { predicates, mode });
     return { library: library || [], cursor: 0 };
   };
 

--- a/src/renderer/platform.ts
+++ b/src/renderer/platform.ts
@@ -13,6 +13,70 @@ export const capabilities = {
   shutdown: isElectron,
 };
 
+// Diagnostics: forward renderer errors/load failures to the main-process file
+// logger (app-log.jsonl) in Electron; in web mode just log to the console.
+export interface RendererLogEntry {
+  level?: 'error' | 'warn' | 'info';
+  scope: string;
+  message: string;
+  data?: unknown;
+  error?: unknown;
+}
+
+export function logEvent(entry: RendererLogEntry): void {
+  try {
+    if (isElectron && (window as any).electron?.logEvent) {
+      (window as any).electron.logEvent({
+        ...entry,
+        error:
+          entry.error instanceof Error
+            ? {
+                name: entry.error.name,
+                message: entry.error.message,
+                stack: entry.error.stack,
+              }
+            : entry.error,
+      });
+    } else {
+      // eslint-disable-next-line no-console
+      console.error('[log]', entry.scope, entry.message, entry.error ?? '');
+    }
+  } catch {
+    // never let logging throw
+  }
+}
+
+// Channels whose handler living in the main process could, in a pathological
+// state, never settle (e.g. a DB lock SQLite doesn't time out). A renderer-side
+// backstop converts that into a rejection so the XState machine's onError fires
+// instead of spinning forever. Generous values: this is a safety net, not the
+// primary timeout (those live in the main process). load-files is intentionally
+// absent — recursive scans of huge trees are legitimately long; its hang case
+// is handled at the source by the child-process inactivity watchdog.
+const INVOKE_TIMEOUT_MS: Record<string, number> = {
+  'load-db': 75_000,
+};
+
+function invokeTimeout<T>(channel: string, promise: Promise<T>): Promise<T> {
+  const ms = INVOKE_TIMEOUT_MS[channel];
+  if (!ms) return promise;
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`invoke('${channel}') timed out after ${ms}ms`));
+    }, ms);
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      }
+    );
+  });
+}
+
 // ---- Types ----
 
 type ThumbnailCache =
@@ -335,8 +399,19 @@ export let findSubtitle: (
 
 if (isElectron) {
   // Electron mode: delegate to window.electron.*
-  invoke = (channel, args) =>
-    window.electron.ipcRenderer.invoke(channel as any, args ?? []);
+  invoke = (channel, args) => {
+    const p = window.electron.ipcRenderer.invoke(channel as any, args ?? []);
+    return invokeTimeout(channel, p).catch((err) => {
+      // Record every failed/timed-out IPC call so a stuck load leaves a trail
+      // in app-log.jsonl. Re-throw so existing onError handling is unchanged.
+      logEvent({
+        scope: `invoke:${channel}`,
+        message: `invoke('${channel}') failed`,
+        error: err,
+      });
+      throw err;
+    });
+  };
   send = (channel, args) =>
     window.electron.ipcRenderer.sendMessage(channel as any, args ?? []);
   on = (channel, cb) => window.electron.ipcRenderer.on(channel, cb) ?? (() => {});

--- a/src/renderer/platform.ts
+++ b/src/renderer/platform.ts
@@ -184,6 +184,16 @@ function channelToEndpoint(channel: string): EndpointMapping | null {
       method: 'GET',
       argsToBody: () => null,
     },
+    'load-path-suggestions': {
+      url: '/api/taxonomy/paths',
+      method: 'GET',
+      argsToBody: (args) => ({ term: args[0] }),
+    },
+    'get-category-count': {
+      url: '/api/taxonomy/category-count',
+      method: 'GET',
+      argsToBody: (args) => ({ category: args[0] }),
+    },
     'create-tag': {
       url: '/api/tags',
       method: 'POST',

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -101,6 +101,7 @@ declare global {
         tags?: string[],
         filteringMode?: string
       ) => Promise<{ path: string }[]>;
+      loadMediaByQuery: (predicates: unknown[], mode: string) => Promise<any>;
       loadDuplicatesByPath: (
         path: string
       ) => Promise<{ library: { path: string }[]; cursor: number }>;

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -43,7 +43,7 @@ interface SessionQueryData {
 }
 
 // State type for tracking which mode the library was loaded from
-type LibraryStateType = 'fs' | 'db' | 'search';
+type LibraryStateType = 'fs' | 'db';
 
 interface SessionPreviousData {
   previousLibrary: SessionLibraryData['library'];

--- a/src/renderer/query/parse.ts
+++ b/src/renderer/query/parse.ts
@@ -1,0 +1,85 @@
+// src/renderer/query/parse.ts
+import type { Predicate, PredicateType, Query } from './types';
+
+// Tokenize respecting double-quoted phrases (mirrors src/main/media.ts
+// parseSearchString, kept here so the renderer owns all parsing).
+function tokenize(input: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < input.length; i++) {
+    const c = input[i];
+    if (c === '"') {
+      inQuotes = !inQuotes;
+    } else if (/\s/.test(c) && !inQuotes) {
+      if (current.trim()) tokens.push(current);
+      current = '';
+    } else {
+      current += c;
+    }
+  }
+  if (current.trim()) tokens.push(current);
+  return tokens;
+}
+
+const PREFIXES: Array<{ prefix: string; type: PredicateType }> = [
+  { prefix: 'in:', type: 'category' },
+  { prefix: 'path:', type: 'path' },
+  { prefix: 'description:', type: 'description' },
+  { prefix: 'hash:', type: 'hash' },
+];
+
+// Strip surrounding quotes that survived tokenization of a prefixed value
+// (e.g. path:"a b" -> the token is path:a b already; quotes only appear when
+// the prefix itself is quoted, which we do not support — defensive trim).
+function clean(value: string): string {
+  return value.replace(/^"|"$/g, '').trim();
+}
+
+export function parseQuery(input: string): Predicate[] {
+  const preds: Predicate[] = [];
+  for (let token of tokenize(input)) {
+    let exclude = false;
+    if (token.startsWith('-')) {
+      exclude = true;
+      token = token.slice(1);
+    }
+    if (token.startsWith('#')) {
+      const value = clean(token.slice(1));
+      if (value) preds.push({ type: 'tag', value, exclude });
+      continue;
+    }
+    let matched = false;
+    for (const { prefix, type } of PREFIXES) {
+      if (token.startsWith(prefix)) {
+        const value = clean(token.slice(prefix.length));
+        if (value) preds.push({ type, value, exclude });
+        matched = true;
+        break;
+      }
+    }
+    if (matched) continue;
+    const value = clean(token);
+    if (value) preds.push({ type: 'description', value, exclude });
+  }
+  return preds;
+}
+
+const TYPE_PREFIX: Record<PredicateType, string> = {
+  tag: '#',
+  category: 'in:',
+  path: 'path:',
+  description: 'description:',
+  hash: 'hash:',
+};
+
+export function serializePredicate(p: Predicate): string {
+  const sign = p.exclude ? '-' : '';
+  const needsQuotes = /\s/.test(p.value);
+  const value = needsQuotes ? `"${p.value}"` : p.value;
+  return `${sign}${TYPE_PREFIX[p.type]}${value}`;
+}
+
+export function serializeQuery(q: Query): string {
+  return q.predicates.map(serializePredicate).join(' ');
+}

--- a/src/renderer/query/reducer.ts
+++ b/src/renderer/query/reducer.ts
@@ -42,3 +42,11 @@ export function setPredicateJoin(q: Query, key: string, join: 'AND' | 'OR'): Que
     ),
   };
 }
+
+// Project the active (included) tag values from a query — the legacy
+// dbQuery.tags view derives from this so it can never desync from `query`.
+export function tagsFromQuery(q: Query): string[] {
+  return q.predicates
+    .filter((p) => p.type === 'tag' && !p.exclude)
+    .map((p) => p.value);
+}

--- a/src/renderer/query/reducer.ts
+++ b/src/renderer/query/reducer.ts
@@ -27,7 +27,7 @@ export function applyTagClick(q: Query, tag: string, mode: string): Query {
   const key = predicateKey({ type: 'tag', value: tag, exclude: false });
   const exists = q.predicates.some((x) => predicateKey(x) === key);
   if (mode === 'EXCLUSIVE') {
-    if (exists && q.predicates.length === 1) return { predicates: [] };
+    if (exists) return { predicates: [] };
     return { predicates: [{ type: 'tag', value: tag, exclude: false }] };
   }
   if (exists) return removePredicate(q, key);

--- a/src/renderer/query/reducer.ts
+++ b/src/renderer/query/reducer.ts
@@ -35,6 +35,18 @@ export function applyTagClick(q: Query, tag: string, mode: string): Query {
   return addPredicate(q, { type: 'tag', value: tag, exclude: false, join });
 }
 
+// Adding a predicate honors EXCLUSIVE mode: in EXCLUSIVE, selecting ANY filter
+// (tag, path, category, description, hash) replaces the entire query with just
+// that predicate. In AND/OR it appends (deduped).
+export function addPredicateWithMode(
+  q: Query,
+  p: Predicate,
+  mode: string
+): Query {
+  if (mode === 'EXCLUSIVE') return { predicates: [p] };
+  return addPredicate(q, p);
+}
+
 export function setPredicateJoin(q: Query, key: string, join: 'AND' | 'OR'): Query {
   return {
     predicates: q.predicates.map((x) =>

--- a/src/renderer/query/reducer.ts
+++ b/src/renderer/query/reducer.ts
@@ -1,0 +1,35 @@
+// src/renderer/query/reducer.ts
+import type { Predicate, Query } from './types';
+import { predicateKey } from './types';
+
+export function addPredicate(q: Query, p: Predicate): Query {
+  const key = predicateKey(p);
+  if (q.predicates.some((x) => predicateKey(x) === key)) return q;
+  return { predicates: [...q.predicates, p] };
+}
+
+export function removePredicate(q: Query, key: string): Query {
+  return { predicates: q.predicates.filter((x) => predicateKey(x) !== key) };
+}
+
+export function toggleExclude(q: Query, key: string): Query {
+  return {
+    predicates: q.predicates.map((x) =>
+      predicateKey(x) === key ? { ...x, exclude: !x.exclude } : x
+    ),
+  };
+}
+
+// Legacy tag-click behavior unified into the query model.
+// AND/OR: toggle the tag in place. EXCLUSIVE: clicking replaces the entire
+// query with that single tag (or clears it if it was the only active tag).
+export function applyTagClick(q: Query, tag: string, mode: string): Query {
+  const key = predicateKey({ type: 'tag', value: tag, exclude: false });
+  const exists = q.predicates.some((x) => predicateKey(x) === key);
+  if (mode === 'EXCLUSIVE') {
+    if (exists && q.predicates.length === 1) return { predicates: [] };
+    return { predicates: [{ type: 'tag', value: tag, exclude: false }] };
+  }
+  if (exists) return removePredicate(q, key);
+  return addPredicate(q, { type: 'tag', value: tag, exclude: false });
+}

--- a/src/renderer/query/reducer.ts
+++ b/src/renderer/query/reducer.ts
@@ -24,12 +24,21 @@ export function toggleExclude(q: Query, key: string): Query {
 // AND/OR: toggle the tag in place. EXCLUSIVE: clicking replaces the entire
 // query with that single tag (or clears it if it was the only active tag).
 export function applyTagClick(q: Query, tag: string, mode: string): Query {
+  const join: 'AND' | 'OR' = mode === 'OR' ? 'OR' : 'AND';
   const key = predicateKey({ type: 'tag', value: tag, exclude: false });
   const exists = q.predicates.some((x) => predicateKey(x) === key);
   if (mode === 'EXCLUSIVE') {
     if (exists) return { predicates: [] };
-    return { predicates: [{ type: 'tag', value: tag, exclude: false }] };
+    return { predicates: [{ type: 'tag', value: tag, exclude: false, join }] };
   }
   if (exists) return removePredicate(q, key);
-  return addPredicate(q, { type: 'tag', value: tag, exclude: false });
+  return addPredicate(q, { type: 'tag', value: tag, exclude: false, join });
+}
+
+export function setPredicateJoin(q: Query, key: string, join: 'AND' | 'OR'): Query {
+  return {
+    predicates: q.predicates.map((x) =>
+      predicateKey(x) === key ? { ...x, join } : x
+    ),
+  };
 }

--- a/src/renderer/query/reducer.ts
+++ b/src/renderer/query/reducer.ts
@@ -13,6 +13,18 @@ export function removePredicate(q: Query, key: string): Query {
 }
 
 export function toggleExclude(q: Query, key: string): Query {
+  const target = q.predicates.find((x) => predicateKey(x) === key);
+  if (!target) return q;
+  // Guard: never produce an all-exclude query (no positive/include anchor).
+  // Such a query has nothing to drive from and scans the entire media table
+  // ("everything except X"), which can hang/crash the app on a large library.
+  // Block toggling the last remaining include predicate to exclude.
+  if (!target.exclude) {
+    const hasOtherInclude = q.predicates.some(
+      (x) => predicateKey(x) !== key && !x.exclude
+    );
+    if (!hasOtherInclude) return q; // would leave zero includes — no-op
+  }
   return {
     predicates: q.predicates.map((x) =>
       predicateKey(x) === key ? { ...x, exclude: !x.exclude } : x

--- a/src/renderer/query/types.ts
+++ b/src/renderer/query/types.ts
@@ -16,6 +16,8 @@ export interface Predicate {
   value: string;
   // Per-predicate include (false) / exclude (true).
   exclude: boolean;
+  // Faceted combine bucket; undefined falls back to the global mode.
+  join?: 'AND' | 'OR';
 }
 
 export interface Query {

--- a/src/renderer/query/types.ts
+++ b/src/renderer/query/types.ts
@@ -1,0 +1,34 @@
+// src/renderer/query/types.ts
+// Structured, composable media query shared by the chip input, the state
+// machine, and the backend query engine. A query is a flat list of
+// predicates joined by the global filtering mode (see settings.FilterModeOption).
+
+export type PredicateType =
+  | 'tag'
+  | 'category'
+  | 'path'
+  | 'description'
+  | 'hash';
+
+export interface Predicate {
+  type: PredicateType;
+  // Exact value for 'tag'/'category'; substring for 'path'/'description'/'hash'.
+  value: string;
+  // Per-predicate include (false) / exclude (true).
+  exclude: boolean;
+}
+
+export interface Query {
+  predicates: Predicate[];
+}
+
+export const EMPTY_QUERY: Query = { predicates: [] };
+
+// Stable identity for a predicate, used for dedupe and React keys.
+export function predicateKey(p: Predicate): string {
+  return `${p.exclude ? '-' : ''}${p.type}:${p.value}`;
+}
+
+export function queryIsEmpty(q: Query): boolean {
+  return !q || q.predicates.length === 0;
+}

--- a/src/renderer/search/search-config.ts
+++ b/src/renderer/search/search-config.ts
@@ -1,0 +1,6 @@
+// Shared debounce window for keystroke-driven type-ahead searches: the tag
+// fuzzy search (useTagSearch) and the IPC-backed suggestion queries — path
+// lookups and per-category counts (SuggestionSections). One knob so every
+// downstream search across the taxonomy sidebar and the command palette
+// coalesces bursts of keystrokes on the same cadence.
+export const SEARCH_DEBOUNCE_MS = 250;

--- a/src/renderer/search/tag-search-service.ts
+++ b/src/renderer/search/tag-search-service.ts
@@ -19,7 +19,8 @@ export interface TagConcept {
 }
 
 // Keep these Fuse options in sync with tag-search.worker.ts and the historical
-// taxonomy fallback.
+// taxonomy fallback. (Not `as const` — Fuse's option types are mutable, and the
+// readonly form trips ts-jest's stricter type check.)
 const FUSE_OPTIONS = {
   keys: [
     { name: 'label', weight: 2 },
@@ -28,7 +29,13 @@ const FUSE_OPTIONS = {
   threshold: 0.4,
   ignoreLocation: true,
   minMatchCharLength: 1,
-} as const;
+};
+
+// Don't dispatch a fuzzy search until the query is at least this long. A 1-char
+// query clears Fuse's threshold against ~every entry in a 175K-tag library, so
+// it both pegs the search and floods the result list with noise. Two characters
+// is the standard type-ahead floor and removes that pathological case.
+const MIN_QUERY_LENGTH = 2;
 
 type ResultCb = (items: TagConcept[]) => void;
 
@@ -39,8 +46,15 @@ let worker: Worker | null = null;
 let useFallback = false;
 // Whether worker setup (or fallback) has been attempted at least once.
 let initialized = false;
-// The last indexed tag array, kept by reference so indexTags can no-op when the
-// same reference is passed again.
+// The raw source array last handed to indexTags, kept by reference so indexing
+// is a no-op when the same reference comes back. All consumers (the startup
+// warmer, the taxonomy sidebar, the command palette) read the SAME React Query
+// cache entry, so they pass an identical reference — meaning the full library is
+// structured-cloned to the worker exactly once, not re-cloned on each surface's
+// first search.
+let indexedSource: TagConcept[] | null = null;
+// The cleaned, indexed tag array (label-less rows dropped). Backs the fallback
+// Fuse instance and isWarm().
 let indexedTags: TagConcept[] | null = null;
 // Synchronous Fuse instance — only built when running without a worker.
 let fallbackFuse: Fuse<TagConcept> | null = null;
@@ -64,46 +78,62 @@ function ensureInit(): void {
     return;
   }
   try {
-    worker = new Worker(
-      new URL('../components/taxonomy/tag-search.worker.ts', import.meta.url)
-    );
+    // Lazy require: the factory carries the `import.meta` worker URL, which the
+    // CommonJS test transform can't parse. We only reach here when a real Worker
+    // exists (never under jsdom), so the test graph never loads that module.
+    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+    const { createTagSearchWorker } = require('./tag-search-worker-factory');
+    worker = createTagSearchWorker();
   } catch {
     worker = null;
     useFallback = true;
     return;
   }
-  worker.onmessage = (e: MessageEvent) => {
-    const msg = e.data;
-    if (msg?.type === 'result') {
-      const cb = pending[msg.id];
-      if (cb) {
-        delete pending[msg.id];
-        cb((msg.items as TagConcept[]) ?? []);
+  if (worker) {
+    worker.onmessage = (e: MessageEvent) => {
+      const msg = e.data;
+      if (msg?.type === 'result') {
+        const cb = pending[msg.id];
+        if (cb) {
+          delete pending[msg.id];
+          cb((msg.items as TagConcept[]) ?? []);
+        }
       }
-    }
-  };
+    };
+  }
 }
 
 /**
- * (Re)index the shared tag set. Idempotent: if the same array reference is
- * passed again it is ignored. Posts the index to the worker, or rebuilds the
- * synchronous Fuse instance when running without a worker.
+ * (Re)index the shared tag set. Idempotent on the SOURCE reference: passing the
+ * same array again is a no-op, so consumers can hand over the raw, shared React
+ * Query array and the full library is cloned to the worker only when the data
+ * actually changes — not once per consumer. Returns whether a (re)index ran.
+ *
+ * The defensive label filter (Fuse and the row renderers assume a non-empty
+ * label) lives here so callers don't each spin up a divergent filtered array,
+ * which is what previously defeated the reference guard.
  */
-export function indexTags(tags: TagConcept[]): void {
+export function indexTags(tags: TagConcept[]): boolean {
   ensureInit();
-  if (tags === indexedTags) return;
-  indexedTags = tags;
+  if (tags === indexedSource) return false;
+  indexedSource = tags;
+  const clean = tags.filter(
+    (t) => t && typeof t.label === 'string' && t.label.length > 0
+  );
+  indexedTags = clean;
   if (worker) {
-    worker.postMessage({ type: 'index', tags });
+    worker.postMessage({ type: 'index', tags: clean });
   } else if (useFallback) {
-    buildFallbackFuse(tags);
+    buildFallbackFuse(clean);
   }
+  return true;
 }
 
 /**
  * Run a search. The callback fires with the ranked results for THIS call.
  * Multiple concurrent callers are routed by an internal incrementing id so
- * they don't clobber each other. An empty query resolves to [] synchronously.
+ * they don't clobber each other. A query shorter than MIN_QUERY_LENGTH (empty
+ * included) resolves to [] synchronously without touching the index.
  */
 export function searchTags(
   query: string,
@@ -111,7 +141,7 @@ export function searchTags(
   cb: ResultCb
 ): void {
   ensureInit();
-  if (!query) {
+  if (!query || query.length < MIN_QUERY_LENGTH) {
     cb([]);
     return;
   }

--- a/src/renderer/search/tag-search-service.ts
+++ b/src/renderer/search/tag-search-service.ts
@@ -1,0 +1,139 @@
+// tag-search-service — a MODULE-LEVEL singleton wrapping ONE shared tag-search
+// worker (plus a synchronous Fuse fallback) for the whole app.
+//
+// Both the taxonomy sidebar (via useTagSearch) and the command palette (via
+// useTagSearch) route through this single index, which is warmed at startup by
+// useWarmTagSearch so the first search from either surface is instant.
+//
+// The worker is constructed lazily on first use and lives for the app lifetime
+// — it is NEVER terminated. Under environments without Web Worker support
+// (e.g. jsdom in tests) construction is guarded and we fall back to a
+// synchronous Fuse search with the SAME options as the worker.
+import Fuse from 'fuse.js';
+
+export interface TagConcept {
+  label: string;
+  category: string;
+  weight: number;
+  description?: string;
+}
+
+// Keep these Fuse options in sync with tag-search.worker.ts and the historical
+// taxonomy fallback.
+const FUSE_OPTIONS = {
+  keys: [
+    { name: 'label', weight: 2 },
+    { name: 'category', weight: 1 },
+  ],
+  threshold: 0.4,
+  ignoreLocation: true,
+  minMatchCharLength: 1,
+} as const;
+
+type ResultCb = (items: TagConcept[]) => void;
+
+// Module-level singleton state.
+let worker: Worker | null = null;
+// True once we've attempted (and failed) to construct a worker, so we know to
+// use the synchronous Fuse fallback instead.
+let useFallback = false;
+// Whether worker setup (or fallback) has been attempted at least once.
+let initialized = false;
+// The last indexed tag array, kept by reference so indexTags can no-op when the
+// same reference is passed again.
+let indexedTags: TagConcept[] | null = null;
+// Synchronous Fuse instance — only built when running without a worker.
+let fallbackFuse: Fuse<TagConcept> | null = null;
+
+// Pending search callbacks keyed by request id so concurrent callers (taxonomy
+// + palette) don't clobber each other.
+let seq = 0;
+const pending: Record<number, ResultCb> = {};
+
+function buildFallbackFuse(tags: TagConcept[]): void {
+  fallbackFuse = new Fuse(tags, FUSE_OPTIONS);
+}
+
+// Lazily set up the shared worker (or mark the fallback). Idempotent.
+function ensureInit(): void {
+  if (initialized) return;
+  initialized = true;
+
+  if (typeof Worker === 'undefined') {
+    useFallback = true;
+    return;
+  }
+  try {
+    worker = new Worker(
+      new URL('../components/taxonomy/tag-search.worker.ts', import.meta.url)
+    );
+  } catch {
+    worker = null;
+    useFallback = true;
+    return;
+  }
+  worker.onmessage = (e: MessageEvent) => {
+    const msg = e.data;
+    if (msg?.type === 'result') {
+      const cb = pending[msg.id];
+      if (cb) {
+        delete pending[msg.id];
+        cb((msg.items as TagConcept[]) ?? []);
+      }
+    }
+  };
+}
+
+/**
+ * (Re)index the shared tag set. Idempotent: if the same array reference is
+ * passed again it is ignored. Posts the index to the worker, or rebuilds the
+ * synchronous Fuse instance when running without a worker.
+ */
+export function indexTags(tags: TagConcept[]): void {
+  ensureInit();
+  if (tags === indexedTags) return;
+  indexedTags = tags;
+  if (worker) {
+    worker.postMessage({ type: 'index', tags });
+  } else if (useFallback) {
+    buildFallbackFuse(tags);
+  }
+}
+
+/**
+ * Run a search. The callback fires with the ranked results for THIS call.
+ * Multiple concurrent callers are routed by an internal incrementing id so
+ * they don't clobber each other. An empty query resolves to [] synchronously.
+ */
+export function searchTags(
+  query: string,
+  limit: number,
+  cb: ResultCb
+): void {
+  ensureInit();
+  if (!query) {
+    cb([]);
+    return;
+  }
+  const id = (seq += 1);
+  if (worker) {
+    pending[id] = cb;
+    worker.postMessage({ type: 'search', id, query, limit });
+    return;
+  }
+  // Synchronous fallback.
+  if (!fallbackFuse) {
+    buildFallbackFuse(indexedTags ?? []);
+  }
+  const items = fallbackFuse
+    ? fallbackFuse.search(query, { limit }).map((r) => r.item)
+    : [];
+  cb(items);
+}
+
+/**
+ * True once the worker (or fallback) is set up and tags have been indexed.
+ */
+export function isWarm(): boolean {
+  return initialized && indexedTags !== null;
+}

--- a/src/renderer/search/tag-search-worker-factory.ts
+++ b/src/renderer/search/tag-search-worker-factory.ts
@@ -1,0 +1,13 @@
+// Isolated tag-search worker bootstrap.
+//
+// The webpack-recognised `new Worker(new URL('...', import.meta.url))` form is
+// what pins the worker as its own chunk at build time — but it also embeds the
+// `import.meta` meta-property, which the CommonJS ts-jest transform refuses to
+// compile (TS1343). Keeping it in this one tiny module, loaded lazily via
+// require() from tag-search-service ONLY when a real Worker exists, keeps the
+// rest of the search service importable (and unit-testable) under jsdom.
+export function createTagSearchWorker(): Worker {
+  return new Worker(
+    new URL('../components/taxonomy/tag-search.worker.ts', import.meta.url)
+  );
+}

--- a/src/renderer/state.tsx
+++ b/src/renderer/state.tsx
@@ -16,6 +16,7 @@ import {
   loadMediaByQuery as platformLoadMediaByQuery,
 } from './platform';
 import type { Query } from './query/types';
+import { predicateKey } from './query/types';
 import {
   addPredicate,
   removePredicate,
@@ -2049,10 +2050,9 @@ export const libraryMachine = createMachine(
                 }),
               },
               CLEAR_QUERY: {
+                // No actions: loadingFromPreviousLibrary's entry restores query/library
+                // from the previous* snapshot (mirrors CLEAR_QUERY_TAG).
                 target: 'loadingFromPreviousLibrary',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: () => ({ predicates: [] }),
-                }),
               },
               SET_TEXT_FILTER: [
                 {
@@ -2324,6 +2324,7 @@ export const libraryMachine = createMachine(
                 libraryLoadId: () => uniqueId(),
                 currentStateType: () => 'search' as LibraryStateType,
                 dbQuery: () => ({ tags: [] }),
+                query: () => ({ predicates: [] }),
               }),
               (context) => updatePersistedState(context),
             ],
@@ -2470,10 +2471,9 @@ export const libraryMachine = createMachine(
                 }),
               },
               CLEAR_QUERY: {
+                // No actions: loadingFromPreviousLibrary's entry restores query/library
+                // from the previous* snapshot (mirrors CLEAR_QUERY_TAG).
                 target: 'loadingFromPreviousLibrary',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: () => ({ predicates: [] }),
-                }),
               },
               SET_TEXT_FILTER: [
                 {
@@ -2765,6 +2765,15 @@ export const libraryMachine = createMachine(
                           (t) => t !== event.data.tag
                         ),
                       }),
+                      query: (context, event) =>
+                        removePredicate(
+                          context.query,
+                          predicateKey({
+                            type: 'tag',
+                            value: event.data.tag,
+                            exclude: false,
+                          })
+                        ),
                     }),
                     (context, event) => {
                       const newTags = (context.dbQuery.tags || []).filter(
@@ -2773,6 +2782,14 @@ export const libraryMachine = createMachine(
                       updatePersistedState({
                         ...context,
                         dbQuery: { tags: newTags },
+                        query: removePredicate(
+                          context.query,
+                          predicateKey({
+                            type: 'tag',
+                            value: event.data.tag,
+                            exclude: false,
+                          })
+                        ),
                       });
                       clearSessionKeys(['library', 'cursor']);
                     },
@@ -3004,10 +3021,9 @@ export const libraryMachine = createMachine(
                 }),
               },
               CLEAR_QUERY: {
+                // No actions: loadingFromPreviousLibrary's entry restores query/library
+                // from the previous* snapshot (mirrors CLEAR_QUERY_TAG).
                 target: 'loadingFromPreviousLibrary',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: () => ({ predicates: [] }),
-                }),
               },
               DELETED_ASSIGNMENT: {
                 // Removing a tag from an image refreshes the current view; it

--- a/src/renderer/state.tsx
+++ b/src/renderer/state.tsx
@@ -22,6 +22,7 @@ import {
   removePredicate,
   toggleExclude,
   applyTagClick,
+  setPredicateJoin,
 } from './query/reducer';
 import { parseQuery } from './query/parse';
 import filter from './filter';
@@ -2041,6 +2042,13 @@ export const libraryMachine = createMachine(
                     toggleExclude(context.query, event.data.key),
                 }),
               },
+              SET_PREDICATE_JOIN: {
+                target: 'runningQuery',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: (context, event) =>
+                    setPredicateJoin(context.query, event.data.key, event.data.join),
+                }),
+              },
               SET_QUERY: {
                 target: 'runningQuery',
                 actions: assign<LibraryState, AnyEventObject>({
@@ -2460,6 +2468,13 @@ export const libraryMachine = createMachine(
                 actions: assign<LibraryState, AnyEventObject>({
                   query: (context, event) =>
                     toggleExclude(context.query, event.data.key),
+                }),
+              },
+              SET_PREDICATE_JOIN: {
+                target: 'runningQuery',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: (context, event) =>
+                    setPredicateJoin(context.query, event.data.key, event.data.join),
                 }),
               },
               SET_QUERY: {
@@ -3010,6 +3025,13 @@ export const libraryMachine = createMachine(
                 actions: assign<LibraryState, AnyEventObject>({
                   query: (context, event) =>
                     toggleExclude(context.query, event.data.key),
+                }),
+              },
+              SET_PREDICATE_JOIN: {
+                target: 'runningQuery',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: (context, event) =>
+                    setPredicateJoin(context.query, event.data.key, event.data.join),
                 }),
               },
               SET_QUERY: {

--- a/src/renderer/state.tsx
+++ b/src/renderer/state.tsx
@@ -35,7 +35,6 @@ import {
   clearSessionKeys,
   flushSession,
   hasPersistedLibrary as checkHasPersistedLibrary,
-  hasPersistedTextFilter as checkHasPersistedTextFilter,
   hasPersistedTags as checkHasPersistedTags,
 } from './hooks/useSessionStore';
 // Job management removed - now handled by external job runner service
@@ -57,7 +56,7 @@ type Props = {
 };
 
 // State type for tracking which mode the library was loaded from
-type LibraryStateType = 'fs' | 'db' | 'search';
+type LibraryStateType = 'fs' | 'db';
 
 type LibraryState = {
   initialFile: string;
@@ -444,10 +443,6 @@ const hasPersistedLibrary = (_context: LibraryState): boolean => {
   return checkHasPersistedLibrary();
 };
 
-const hasPersistedTextFilter = (_context: LibraryState): boolean => {
-  return checkHasPersistedTextFilter();
-};
-
 const hasPersistedTags = (_context: LibraryState): boolean => {
   return checkHasPersistedTags();
 };
@@ -740,9 +735,9 @@ const getInitialContext = (): LibraryState => {
 };
 
 // Shared query-mutation handlers. Defined once so they can be applied to both
-// the loaded states (loadedFromFS/loadedFromSearch/loadedFromDB) and the
-// loading states (runningQuery/switchingTag/loadingFromDB/loadingFromSearch/
-// changingSearch). Applying them while a query is in flight makes chip edits
+// the loaded states (loadedFromFS/loadedFromDB) and the
+// loading states (runningQuery/switchingTag/loadingFromDB). Applying them while
+// a query is in flight makes chip edits
 // feel snappy: the assign updates context.query immediately (so the chip UI
 // updates) and targeting runningQuery restarts execution with the latest
 // predicates (latest-wins).
@@ -1467,7 +1462,6 @@ export const libraryMachine = createMachine(
               },
             }),
             always: [
-              { target: 'loadingFromSearch', cond: hasPersistedTextFilter },
               { target: 'loadingFromDB', cond: hasPersistedTags },
               { target: 'selectingDirectory' },
             ],
@@ -1719,56 +1713,6 @@ export const libraryMachine = createMachine(
             },
             on: { ...queryMutationOn },
           },
-          loadingFromSearch: {
-            invoke: {
-              src: (context, event) => {
-                console.log(
-                  'initial search',
-                  context.textFilter,
-                  context.dbQuery.tags,
-                  context.settings.filteringMode
-                );
-                return platformLoadMediaByDescriptionSearch(
-                  context.textFilter,
-                  context.dbQuery.tags,
-                  context.settings.filteringMode
-                );
-              },
-              onDone: {
-                target: 'loadedFromSearch',
-                actions: ['setLibraryWithPrevious'],
-              },
-              onError: {
-                target: 'loadedFromFS',
-              },
-            },
-            on: { ...queryMutationOn },
-          },
-          changingSearch: {
-            invoke: {
-              src: (context, event) => {
-                console.log(
-                  'changing Search',
-                  context.textFilter,
-                  context.dbQuery.tags,
-                  context.settings.filteringMode
-                );
-                return platformLoadMediaByDescriptionSearch(
-                  context.textFilter,
-                  context.dbQuery.tags,
-                  context.settings.filteringMode
-                );
-              },
-              onDone: {
-                target: 'loadedFromSearch',
-                actions: ['setLibrary'],
-              },
-              onError: {
-                target: 'loadedFromFS',
-              },
-            },
-            on: { ...queryMutationOn },
-          },
           switchingTag: {
             invoke: {
               src: (context, event) => {
@@ -1881,7 +1825,6 @@ export const libraryMachine = createMachine(
               libraryLoadId: () => uniqueId(),
             }),
             always: [
-              { target: 'loadedFromSearch', cond: hasPersistedTextFilter },
               { target: 'loadedFromDB', cond: hasPersistedTags },
               { target: 'loadedFromFS' },
             ],
@@ -1942,10 +1885,6 @@ export const libraryMachine = createMachine(
               {
                 target: 'loadedFromDB',
                 cond: (context) => context.currentStateType === 'db',
-              },
-              {
-                target: 'loadedFromSearch',
-                cond: (context) => context.currentStateType === 'search',
               },
               {
                 // If previous library is empty and we're going back to FS mode,
@@ -2129,45 +2068,6 @@ export const libraryMachine = createMachine(
                       });
                       // Invalidate persisted library snapshot to avoid query/library mismatch
                       clearSessionKeys(['library', 'cursor']);
-                    },
-                  ],
-                },
-              ],
-              SET_TEXT_FILTER: [
-                {
-                  cond: notEmpty,
-                  target: 'loadingFromSearch',
-                  actions: [
-                    capturePrevious,
-                    persistPreviousState,
-                    assign<LibraryState, AnyEventObject>({
-                      textFilter: (context, event) => {
-                        console.log('SET_TEXT_FILTER', context, event);
-                        return event.data.textFilter;
-                      },
-                      // Clear tag filters when entering search mode (mutually exclusive)
-                      dbQuery: () => ({ tags: [] }),
-                    }),
-                    (context, event) => {
-                      updatePersistedState({
-                        ...context,
-                        textFilter: event.data.textFilter,
-                        dbQuery: { tags: [] },
-                      });
-                      clearSessionKeys(['library', 'cursor']);
-                    },
-                  ],
-                },
-                {
-                  // Empty text in FS mode is a no-op for the library — just
-                  // clear textFilter without leaving FS or running a search.
-                  cond: isEmpty,
-                  actions: [
-                    assign<LibraryState, AnyEventObject>({
-                      textFilter: () => '',
-                    }),
-                    (context) => {
-                      updatePersistedState({ ...context, textFilter: '' });
                     },
                   ],
                 },
@@ -2393,285 +2293,6 @@ export const libraryMachine = createMachine(
               },
             },
           },
-          loadedFromSearch: {
-            initial: 'idle',
-            // Invariant: in search mode, tag query is empty (search and tags
-            // are mutually exclusive in this app). Force dbQuery.tags=[] on
-            // entry so a stale tag set can't surface alongside search results.
-            entry: [
-              assign<LibraryState, AnyEventObject>({
-                libraryLoadId: () => uniqueId(),
-                currentStateType: () => 'search' as LibraryStateType,
-                dbQuery: () => ({ tags: [] }),
-                query: () => ({ predicates: [] }),
-              }),
-              (context) => updatePersistedState(context),
-            ],
-            states: {
-              idle: {},
-            },
-            on: {
-              ...queryMutationOn,
-              LOAD_FILES_BATCH: {
-                actions: assign<LibraryState, AnyEventObject>({
-                  library: (context, event) => {
-                    // Use the sorted/filtered view to look up the current item,
-                    // since cursor is an index into the sorted view, not the raw library
-                    const currentView = filter(
-                      context.libraryLoadId,
-                      context.textFilter,
-                      context.library,
-                      context.settings.filters,
-                      context.settings.sortBy
-                    );
-                    const previousSelectedPath =
-                      context.pinnedPath ||
-                      currentView[context.cursor]?.path;
-                    // Use case-insensitive path matching to avoid duplicates on Windows
-                    const existing = new Set(
-                      context.library.map((item) => item.path.toLowerCase())
-                    );
-                    const incoming = (event.data?.files || []) as Item[];
-                    const newItems = incoming.filter(
-                      (f) => f?.path && !existing.has(f.path.toLowerCase())
-                    );
-                    const updatedLibrary = context.library.concat(newItems);
-
-                    if (previousSelectedPath) {
-                      const tempLibraryLoadId = 'batch-' + uniqueId();
-                      const sorted = filter(
-                        tempLibraryLoadId,
-                        context.textFilter,
-                        updatedLibrary,
-                        context.settings.filters,
-                        (context.streaming
-                          ? 'stream'
-                          : context.settings.sortBy) as any
-                      );
-                      const newIndex = sorted.findIndex(
-                        (item: Item) =>
-                          item?.path &&
-                          path.normalize(item.path).toLowerCase() ===
-                            path.normalize(previousSelectedPath).toLowerCase()
-                      );
-                      if (newIndex !== -1) {
-                        updatePersistedCursor(context, newIndex);
-                        (event as any).__newCursor = newIndex;
-                      }
-                    }
-
-                    return updatedLibrary;
-                  },
-                  cursor: (context, event) => {
-                    const computed = (event as any).__newCursor as
-                      | number
-                      | undefined;
-                    return typeof computed === 'number'
-                      ? computed
-                      : context.cursor;
-                  },
-                  libraryLoadId: () => uniqueId(),
-                  streaming: () => true,
-                }),
-              },
-              // When tag is changed in search mode, clear search and switch to tag-based DB loading
-              SET_QUERY_TAG: [
-                {
-                  target: 'loadingFromDB',
-                  cond: willHaveTag,
-                  actions: [
-                    capturePrevious,
-                    persistPreviousState,
-                    assign<LibraryState, AnyEventObject>({
-                      // Clear text filter when switching to tag mode (mutually exclusive)
-                      textFilter: () => '',
-                      dbQuery: (context, event) => {
-                        console.log(
-                          'SET_QUERY_TAG from search - switching to tag mode',
-                          context,
-                          event.data.tag
-                        );
-                        return { tags: [event.data.tag] };
-                      },
-                      // Mirror the tag click into the unified query model.
-                      query: (context, event) =>
-                        applyTagClick(
-                          context.query,
-                          event.data.tag,
-                          context.settings.filteringMode
-                        ),
-                    }),
-                    (context, event) => {
-                      updatePersistedState({
-                        ...context,
-                        textFilter: '',
-                        dbQuery: { tags: [event.data.tag] },
-                        query: applyTagClick(
-                          context.query,
-                          event.data.tag,
-                          context.settings.filteringMode
-                        ),
-                      });
-                      clearSessionKeys(['library', 'cursor']);
-                    },
-                  ],
-                },
-                // willHaveNoTag branch removed — search mode invariant is
-                // dbQuery.tags === [], so toggling any new tag yields a
-                // single-tag set (handled above) and the empty-result branch
-                // is unreachable.
-              ],
-              SET_TEXT_FILTER: [
-                {
-                  cond: notEmpty,
-                  target: 'changingSearch',
-                  actions: [
-                    assign<LibraryState, AnyEventObject>({
-                      textFilter: (context, event) => {
-                        console.log('Changing Search', context, event);
-                        return event.data.textFilter;
-                      },
-                      // Ensure tags stay cleared in search mode (mutually exclusive)
-                      dbQuery: () => ({ tags: [] }),
-                    }),
-                    (context, event) => {
-                      updatePersistedState({
-                        ...context,
-                        textFilter: event.data.textFilter,
-                        dbQuery: { tags: [] },
-                      });
-                      // Invalidate persisted library snapshot to avoid query/library mismatch
-                      clearSessionKeys(['library', 'cursor']);
-                    },
-                  ],
-                },
-                {
-                  // Empty text exits search mode. Don't write textFilter or
-                  // dbQuery here — loadingFromPreviousLibrary's entry will
-                  // restore them from previous*. Writing intermediate
-                  // {textFilter: '', dbQuery: {tags: []}} to the session
-                  // store before the restore would briefly persist a
-                  // corrupt query if the app flushed in that window.
-                  cond: isEmpty,
-                  target: 'loadingFromPreviousLibrary',
-                },
-              ],
-              DELETE_FILE: {
-                actions: [
-                  assign<LibraryState, AnyEventObject>({
-                    library: (context, event) => {
-                      console.log('DELETE_FILE', context, event);
-                      try {
-                        invoke('delete-file', [
-                          event.data.path,
-                        ]);
-                      } catch (e) {
-                        console.error(e);
-                      }
-                      const path = event.data.path;
-                      const library = [...context.library];
-                      const index = library.findIndex(
-                        (item) => item.path === path
-                      );
-                      if (index > -1) {
-                        library.splice(index, 1);
-                      }
-                      return library;
-                    },
-                    cursor: (context) => {
-                      // If the cursor was on the last item in the library, decrement it.
-                      if (context.cursor >= context.library.length - 1) {
-                        return context.cursor - 1;
-                      }
-                      return context.cursor;
-                    },
-                    libraryLoadId: () => uniqueId(),
-                  }),
-                  assign<LibraryState, AnyEventObject>({
-                    toasts: (context, event) => {
-                      const filename =
-                        event.data.path.split(/[\\/]/).pop() || event.data.path;
-                      const newToast = {
-                        id: uniqueId(),
-                        type: 'info' as const,
-                        title: 'File deleted',
-                        message: filename,
-                        timestamp: Date.now(),
-                      };
-                      return [...context.toasts, newToast];
-                    },
-                  }),
-                ],
-              },
-              SET_ACTIVE_CATEGORY: {
-                actions: assign<LibraryState, AnyEventObject>({
-                  activeCategory: (context, event) => {
-                    console.log('SET_ACTIVE_CATEGORY', context, event);
-                    store.set('activeCategory', event.data.category);
-                    return event.data.category;
-                  },
-                }),
-              },
-              SELECT_FILE: {
-                target: 'selecting',
-              },
-              SELECT_DIRECTORY: {
-                target: 'selectingDirectory',
-              },
-              SET_FILE: {
-                target: 'loadingFromFS',
-                actions: [
-                  capturePrevious,
-                  persistPreviousState,
-                  assign<LibraryState, AnyEventObject>({
-                    textFilter: () => '',
-                    initialFile: (context, event) => event.path,
-                  }),
-                ],
-              },
-              CHANGE_DB_PATH: {
-                target: 'selectingDB',
-              },
-              UPDATE_FILE_PATH: {
-                target: 'selectingFilePath',
-              },
-              SHUFFLE: {
-                actions: assign<LibraryState, AnyEventObject>({
-                  cursor: 0,
-                  libraryLoadId: () => uniqueId(),
-                  settings: (context, event) => {
-                    console.log('SHUFFLE', context, event);
-                    return {
-                      ...context.settings,
-                      sortBy: 'shuffle',
-                    };
-                  },
-                }),
-              },
-              UPDATE_MEDIA_ELO: {
-                actions: assign<LibraryState, AnyEventObject>({
-                  library: (context, event) => {
-                    console.log('UPDATE_MEDIA_ELO', context, event);
-                    const { path, elo } = event;
-                    const library = [...context.library];
-                    const item = library.find((item) => item.path === path);
-                    if (item) {
-                      item.elo = elo;
-                    }
-                    return library;
-                  },
-                  libraryLoadId: () => uniqueId(),
-                }),
-              },
-              SET_SCROLL_POSITION: {
-                actions: assign<LibraryState, AnyEventObject>({
-                  scrollPosition: (context, event) => {
-                    return event.position;
-                  },
-                }),
-              },
-            },
-          },
           loadedFromDB: {
             initial: 'idle',
             // Invariant: in tag (DB) mode, description search is empty (tags
@@ -2846,31 +2467,6 @@ export const libraryMachine = createMachine(
                   target: 'loadingFromPreviousLibrary',
                 },
               ],
-              SET_TEXT_FILTER: {
-                target: 'loadingFromSearch',
-                actions: [
-                  capturePrevious,
-                  persistPreviousState,
-                  assign<LibraryState, AnyEventObject>({
-                    cursor: 0,
-                    libraryLoadId: () => uniqueId(),
-                    textFilter: (context, event) => {
-                      console.log('SET_TEXT_FILTER', context, event);
-                      return event.data.textFilter;
-                    },
-                    // Clear tag filters when entering search mode (mutually exclusive)
-                    dbQuery: () => ({ tags: [] }),
-                  }),
-                  (context, event) => {
-                    updatePersistedState({
-                      ...context,
-                      textFilter: event.data.textFilter,
-                      dbQuery: { tags: [] },
-                    });
-                    clearSessionKeys(['library', 'cursor']);
-                  },
-                ],
-              },
               SHUFFLE: {
                 actions: assign<LibraryState, AnyEventObject>({
                   cursor: 0,

--- a/src/renderer/state.tsx
+++ b/src/renderer/state.tsx
@@ -23,6 +23,7 @@ import {
   toggleExclude,
   applyTagClick,
   setPredicateJoin,
+  tagsFromQuery,
 } from './query/reducer';
 import { parseQuery } from './query/parse';
 import filter from './filter';
@@ -724,38 +725,37 @@ const getInitialContext = (): LibraryState => {
 const queryMutationOn = {
   ADD_PREDICATE: {
     target: 'runningQuery',
-    actions: assign<LibraryState, AnyEventObject>({
-      query: (context, event) =>
-        addPredicate(context.query, event.data.predicate),
+    actions: assign<LibraryState, AnyEventObject>((context, event) => {
+      const q = addPredicate(context.query, event.data.predicate);
+      return { query: q, dbQuery: { tags: tagsFromQuery(q) } };
     }),
   },
   REMOVE_PREDICATE: {
     target: 'runningQuery',
-    actions: assign<LibraryState, AnyEventObject>({
-      query: (context, event) =>
-        removePredicate(context.query, event.data.key),
+    actions: assign<LibraryState, AnyEventObject>((context, event) => {
+      const q = removePredicate(context.query, event.data.key);
+      return { query: q, dbQuery: { tags: tagsFromQuery(q) } };
     }),
   },
   TOGGLE_EXCLUDE: {
     target: 'runningQuery',
-    actions: assign<LibraryState, AnyEventObject>({
-      query: (context, event) =>
-        toggleExclude(context.query, event.data.key),
+    actions: assign<LibraryState, AnyEventObject>((context, event) => {
+      const q = toggleExclude(context.query, event.data.key);
+      return { query: q, dbQuery: { tags: tagsFromQuery(q) } };
     }),
   },
   SET_PREDICATE_JOIN: {
     target: 'runningQuery',
-    actions: assign<LibraryState, AnyEventObject>({
-      query: (context, event) =>
-        setPredicateJoin(context.query, event.data.key, event.data.join),
+    actions: assign<LibraryState, AnyEventObject>((context, event) => {
+      const q = setPredicateJoin(context.query, event.data.key, event.data.join);
+      return { query: q, dbQuery: { tags: tagsFromQuery(q) } };
     }),
   },
   SET_QUERY: {
     target: 'runningQuery',
-    actions: assign<LibraryState, AnyEventObject>({
-      query: (_context, event) => ({
-        predicates: parseQuery(event.data.text),
-      }),
+    actions: assign<LibraryState, AnyEventObject>((_context, event) => {
+      const q = { predicates: parseQuery(event.data.text) };
+      return { query: q, dbQuery: { tags: tagsFromQuery(q) } };
     }),
   },
   CLEAR_QUERY: {
@@ -1934,6 +1934,7 @@ export const libraryMachine = createMachine(
               (context) => updatePersistedState(context),
             ],
             on: {
+              ...queryMutationOn,
               SELECT_FILE: {
                 target: 'selecting',
               },
@@ -2077,47 +2078,6 @@ export const libraryMachine = createMachine(
                   ],
                 },
               ],
-              ADD_PREDICATE: {
-                target: 'runningQuery',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: (context, event) =>
-                    addPredicate(context.query, event.data.predicate),
-                }),
-              },
-              REMOVE_PREDICATE: {
-                target: 'runningQuery',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: (context, event) =>
-                    removePredicate(context.query, event.data.key),
-                }),
-              },
-              TOGGLE_EXCLUDE: {
-                target: 'runningQuery',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: (context, event) =>
-                    toggleExclude(context.query, event.data.key),
-                }),
-              },
-              SET_PREDICATE_JOIN: {
-                target: 'runningQuery',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: (context, event) =>
-                    setPredicateJoin(context.query, event.data.key, event.data.join),
-                }),
-              },
-              SET_QUERY: {
-                target: 'runningQuery',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: (_context, event) => ({
-                    predicates: parseQuery(event.data.text),
-                  }),
-                }),
-              },
-              CLEAR_QUERY: {
-                // No actions: loadingFromPreviousLibrary's entry restores query/library
-                // from the previous* snapshot (mirrors CLEAR_QUERY_TAG).
-                target: 'loadingFromPreviousLibrary',
-              },
               SET_TEXT_FILTER: [
                 {
                   cond: notEmpty,
@@ -2396,6 +2356,7 @@ export const libraryMachine = createMachine(
               idle: {},
             },
             on: {
+              ...queryMutationOn,
               LOAD_FILES_BATCH: {
                 actions: assign<LibraryState, AnyEventObject>({
                   library: (context, event) => {
@@ -2505,47 +2466,6 @@ export const libraryMachine = createMachine(
                 // single-tag set (handled above) and the empty-result branch
                 // is unreachable.
               ],
-              ADD_PREDICATE: {
-                target: 'runningQuery',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: (context, event) =>
-                    addPredicate(context.query, event.data.predicate),
-                }),
-              },
-              REMOVE_PREDICATE: {
-                target: 'runningQuery',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: (context, event) =>
-                    removePredicate(context.query, event.data.key),
-                }),
-              },
-              TOGGLE_EXCLUDE: {
-                target: 'runningQuery',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: (context, event) =>
-                    toggleExclude(context.query, event.data.key),
-                }),
-              },
-              SET_PREDICATE_JOIN: {
-                target: 'runningQuery',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: (context, event) =>
-                    setPredicateJoin(context.query, event.data.key, event.data.join),
-                }),
-              },
-              SET_QUERY: {
-                target: 'runningQuery',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: (_context, event) => ({
-                    predicates: parseQuery(event.data.text),
-                  }),
-                }),
-              },
-              CLEAR_QUERY: {
-                // No actions: loadingFromPreviousLibrary's entry restores query/library
-                // from the previous* snapshot (mirrors CLEAR_QUERY_TAG).
-                target: 'loadingFromPreviousLibrary',
-              },
               SET_TEXT_FILTER: [
                 {
                   cond: notEmpty,
@@ -2711,6 +2631,7 @@ export const libraryMachine = createMachine(
               (context) => updatePersistedState(context),
             ],
             on: {
+              ...queryMutationOn,
               LOAD_FILES_BATCH: {
                 actions: assign<LibraryState, AnyEventObject>({
                   library: (context, event) => {
@@ -3062,47 +2983,6 @@ export const libraryMachine = createMachine(
                   cond: willHaveNoTag,
                 },
               ],
-              ADD_PREDICATE: {
-                target: 'runningQuery',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: (context, event) =>
-                    addPredicate(context.query, event.data.predicate),
-                }),
-              },
-              REMOVE_PREDICATE: {
-                target: 'runningQuery',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: (context, event) =>
-                    removePredicate(context.query, event.data.key),
-                }),
-              },
-              TOGGLE_EXCLUDE: {
-                target: 'runningQuery',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: (context, event) =>
-                    toggleExclude(context.query, event.data.key),
-                }),
-              },
-              SET_PREDICATE_JOIN: {
-                target: 'runningQuery',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: (context, event) =>
-                    setPredicateJoin(context.query, event.data.key, event.data.join),
-                }),
-              },
-              SET_QUERY: {
-                target: 'runningQuery',
-                actions: assign<LibraryState, AnyEventObject>({
-                  query: (_context, event) => ({
-                    predicates: parseQuery(event.data.text),
-                  }),
-                }),
-              },
-              CLEAR_QUERY: {
-                // No actions: loadingFromPreviousLibrary's entry restores query/library
-                // from the previous* snapshot (mirrors CLEAR_QUERY_TAG).
-                target: 'loadingFromPreviousLibrary',
-              },
               DELETED_ASSIGNMENT: {
                 // Removing a tag from an image refreshes the current view; it
                 // doesn't navigate. Capture the current libraryLoadId so the

--- a/src/renderer/state.tsx
+++ b/src/renderer/state.tsx
@@ -13,7 +13,16 @@ import {
   invoke, send, on, store, appArgs, capabilities, isElectron,
   loadMediaFromDB as platformLoadMediaFromDB,
   loadMediaByDescriptionSearch as platformLoadMediaByDescriptionSearch,
+  loadMediaByQuery as platformLoadMediaByQuery,
 } from './platform';
+import type { Query } from './query/types';
+import {
+  addPredicate,
+  removePredicate,
+  toggleExclude,
+  applyTagClick,
+} from './query/reducer';
+import { parseQuery } from './query/parse';
 import filter from './filter';
 import {
   initSessionStore,
@@ -61,6 +70,7 @@ type LibraryState = {
   previousStateType: LibraryStateType | null;
   previousTextFilter: string;
   previousDbQuery: { tags: string[] };
+  previousQuery: Query;
   // Path the library was loaded for. Captured alongside previousLibrary
   // so back-restoration keeps the UI's path/filter/search/library
   // coherent — without this, library and initialFile drift apart.
@@ -112,6 +122,7 @@ type LibraryState = {
   dbQuery: {
     tags: string[];
   };
+  query: Query;
   commandPalette: {
     display: boolean;
     position: { x: number; y: number };
@@ -175,6 +186,7 @@ const capturePrevious = assign<LibraryState, AnyEventObject>({
   previousStateType: (context) => context.currentStateType,
   previousTextFilter: (context) => context.textFilter,
   previousDbQuery: (context) => ({ ...context.dbQuery }),
+  previousQuery: (context) => ({ predicates: [...context.query.predicates] }),
   previousInitialFile: (context) => context.initialFile,
 });
 
@@ -200,6 +212,10 @@ const setLibraryWithPrevious = assign<LibraryState, AnyEventObject>({
     context.previousLibrary.length > 0
       ? context.previousDbQuery
       : { ...context.dbQuery },
+  previousQuery: (context) =>
+    context.previousLibrary.length > 0
+      ? context.previousQuery
+      : { predicates: [...context.query.predicates] },
   previousInitialFile: (context) =>
     context.previousLibrary.length > 0
       ? context.previousInitialFile
@@ -223,6 +239,9 @@ const setLibraryWithPrevious = assign<LibraryState, AnyEventObject>({
     const previousDbQuery = hasPrevious
       ? context.previousDbQuery
       : context.dbQuery;
+    const previousQuery = hasPrevious
+      ? context.previousQuery
+      : context.query;
     const previousInitialFile = hasPrevious
       ? context.previousInitialFile
       : context.initialFile;
@@ -237,6 +256,7 @@ const setLibraryWithPrevious = assign<LibraryState, AnyEventObject>({
         previousStateType,
         previousTextFilter,
         previousDbQuery,
+        previousQuery,
         previousInitialFile,
       },
     });
@@ -264,6 +284,7 @@ const updatePersistedState = (context: LibraryState) => {
   // Update query state using session store (async, debounced)
   setSessionValue('query', {
     dbQuery: context.dbQuery,
+    query: context.query,
     mostRecentTag: context.mostRecentTag,
     mostRecentCategory: context.mostRecentCategory,
     textFilter: context.textFilter,
@@ -281,6 +302,7 @@ const persistPreviousState = (context: LibraryState) => {
     previousStateType: context.previousStateType,
     previousTextFilter: context.previousTextFilter,
     previousDbQuery: context.previousDbQuery,
+    previousQuery: context.previousQuery,
     previousInitialFile: context.previousInitialFile,
   });
 };
@@ -312,6 +334,8 @@ const setPath = assign<LibraryState, AnyEventObject>({
     event.data ? '' : context.previousTextFilter,
   previousDbQuery: (context, event) =>
     event.data ? { tags: [] } : context.previousDbQuery,
+  previousQuery: (context, event) =>
+    event.data ? { predicates: [] } : context.previousQuery,
   previousInitialFile: (context, event) =>
     event.data ? '' : context.previousInitialFile,
 });
@@ -375,6 +399,10 @@ const setDB = assign<LibraryState, AnyEventObject>({
     event.data && event.data !== context.dbPath
       ? { tags: [] }
       : context.previousDbQuery,
+  previousQuery: (context, event) =>
+    event.data && event.data !== context.dbPath
+      ? { predicates: [] }
+      : context.previousQuery,
   previousInitialFile: (context, event) =>
     event.data && event.data !== context.dbPath
       ? ''
@@ -545,6 +573,7 @@ const getInitialContext = (): LibraryState => {
     previousStateType: null,
     previousTextFilter: '',
     previousDbQuery: { tags: [] },
+    previousQuery: { predicates: [] },
     previousInitialFile: '',
     scrollPosition: 0,
     previousScrollPosition: 0,
@@ -661,6 +690,7 @@ const getInitialContext = (): LibraryState => {
     dbQuery: {
       tags: [],
     },
+    query: { predicates: [] },
     commandPalette: {
       display: false,
       position: { x: 0, y: 0 },
@@ -1277,6 +1307,10 @@ export const libraryMachine = createMachine(
                 const queryData = getSessionValue('query');
                 return queryData ? queryData.dbQuery : { tags: [] };
               },
+              query: () => {
+                const queryData = getSessionValue('query');
+                return queryData?.query ?? { predicates: [] };
+              },
               mostRecentTag: () => {
                 const queryData = getSessionValue('query');
                 return queryData ? queryData.mostRecentTag : '';
@@ -1314,6 +1348,10 @@ export const libraryMachine = createMachine(
               previousDbQuery: () => {
                 const previousData = getSessionValue('previous');
                 return previousData?.previousDbQuery ?? { tags: [] };
+              },
+              previousQuery: () => {
+                const previousData = getSessionValue('previous');
+                return previousData?.previousQuery ?? { predicates: [] };
               },
               previousInitialFile: () => {
                 const previousData = getSessionValue('previous');
@@ -1368,6 +1406,7 @@ export const libraryMachine = createMachine(
               libraryLoadId: () => uniqueId(),
               cursor: 0,
               dbQuery: () => ({ tags: [] }),
+              query: () => ({ predicates: [] }),
               streaming: () => true,
               pinnedPath: (context) => context.initialFile,
               savedSortByDuringStreaming: (context) => context.settings.sortBy,
@@ -1637,6 +1676,25 @@ export const libraryMachine = createMachine(
               },
             },
           },
+          // Unified query loader. Runs the structured `query` predicate list
+          // through a single platform service. New query events (ADD_PREDICATE,
+          // REMOVE_PREDICATE, TOGGLE_EXCLUDE, SET_QUERY) target this state.
+          runningQuery: {
+            invoke: {
+              src: (context) =>
+                platformLoadMediaByQuery(
+                  context.query.predicates,
+                  context.settings.filteringMode
+                ),
+              onDone: {
+                target: 'loadedFromDB',
+                actions: ['setLibrary'],
+              },
+              onError: {
+                target: 'loadedFromFS',
+              },
+            },
+          },
           loadingFromPersisted: {
             entry: assign<LibraryState, AnyEventObject>({
               library: (context) => {
@@ -1679,6 +1737,10 @@ export const libraryMachine = createMachine(
                 const previousData = getSessionValue('previous');
                 return previousData?.previousDbQuery ?? { tags: [] };
               },
+              previousQuery: () => {
+                const previousData = getSessionValue('previous');
+                return previousData?.previousQuery ?? { predicates: [] };
+              },
               previousInitialFile: () => {
                 const previousData = getSessionValue('previous');
                 return previousData?.previousInitialFile ?? '';
@@ -1686,6 +1748,10 @@ export const libraryMachine = createMachine(
               dbQuery: () => {
                 const queryData = getSessionValue('query');
                 return queryData ? queryData.dbQuery : { tags: [] };
+              },
+              query: () => {
+                const queryData = getSessionValue('query');
+                return queryData?.query ?? { predicates: [] };
               },
               mostRecentTag: () => {
                 const queryData = getSessionValue('query');
@@ -1719,6 +1785,9 @@ export const libraryMachine = createMachine(
                 cursor: (context) => context.previousCursor,
                 textFilter: (context) => context.previousTextFilter,
                 dbQuery: (context) => ({ ...context.previousDbQuery }),
+                query: (context) => ({
+                  predicates: [...context.previousQuery.predicates],
+                }),
                 initialFile: (context) =>
                   context.previousInitialFile || context.initialFile,
                 currentStateType: (context) =>
@@ -1730,6 +1799,7 @@ export const libraryMachine = createMachine(
                 previousStateType: () => null,
                 previousTextFilter: () => '',
                 previousDbQuery: () => ({ tags: [] }),
+                previousQuery: () => ({ predicates: [] }),
                 previousInitialFile: () => '',
               }),
               // Mirror the restored snapshot to the session store. context
@@ -1748,6 +1818,7 @@ export const libraryMachine = createMachine(
                     previousStateType: null,
                     previousTextFilter: '',
                     previousDbQuery: { tags: [] },
+                    previousQuery: { predicates: [] },
                     previousInitialFile: '',
                   },
                 });
@@ -1796,6 +1867,7 @@ export const libraryMachine = createMachine(
                 currentStateType: () => 'fs' as LibraryStateType,
                 textFilter: () => '',
                 dbQuery: () => ({ tags: [] }),
+                query: () => ({ predicates: [] }),
               }),
               // Mirror the cleared invariant to session storage so a folder
               // load can never leave session.query holding stale tags. Without
@@ -1923,11 +1995,23 @@ export const libraryMachine = createMachine(
                         );
                         return { tags: [event.data.tag] };
                       },
+                      // Mirror the tag click into the unified query model.
+                      query: (context, event) =>
+                        applyTagClick(
+                          context.query,
+                          event.data.tag,
+                          context.settings.filteringMode
+                        ),
                     }),
                     (context, event) => {
                       updatePersistedState({
                         ...context,
                         dbQuery: { tags: [event.data.tag] },
+                        query: applyTagClick(
+                          context.query,
+                          event.data.tag,
+                          context.settings.filteringMode
+                        ),
                       });
                       // Invalidate persisted library snapshot to avoid query/library mismatch
                       clearSessionKeys(['library', 'cursor']);
@@ -1935,6 +2019,41 @@ export const libraryMachine = createMachine(
                   ],
                 },
               ],
+              ADD_PREDICATE: {
+                target: 'runningQuery',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: (context, event) =>
+                    addPredicate(context.query, event.data.predicate),
+                }),
+              },
+              REMOVE_PREDICATE: {
+                target: 'runningQuery',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: (context, event) =>
+                    removePredicate(context.query, event.data.key),
+                }),
+              },
+              TOGGLE_EXCLUDE: {
+                target: 'runningQuery',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: (context, event) =>
+                    toggleExclude(context.query, event.data.key),
+                }),
+              },
+              SET_QUERY: {
+                target: 'runningQuery',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: (_context, event) => ({
+                    predicates: parseQuery(event.data.text),
+                  }),
+                }),
+              },
+              CLEAR_QUERY: {
+                target: 'loadingFromPreviousLibrary',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: () => ({ predicates: [] }),
+                }),
+              },
               SET_TEXT_FILTER: [
                 {
                   cond: notEmpty,
@@ -2293,12 +2412,24 @@ export const libraryMachine = createMachine(
                         );
                         return { tags: [event.data.tag] };
                       },
+                      // Mirror the tag click into the unified query model.
+                      query: (context, event) =>
+                        applyTagClick(
+                          context.query,
+                          event.data.tag,
+                          context.settings.filteringMode
+                        ),
                     }),
                     (context, event) => {
                       updatePersistedState({
                         ...context,
                         textFilter: '',
                         dbQuery: { tags: [event.data.tag] },
+                        query: applyTagClick(
+                          context.query,
+                          event.data.tag,
+                          context.settings.filteringMode
+                        ),
                       });
                       clearSessionKeys(['library', 'cursor']);
                     },
@@ -2309,6 +2440,41 @@ export const libraryMachine = createMachine(
                 // single-tag set (handled above) and the empty-result branch
                 // is unreachable.
               ],
+              ADD_PREDICATE: {
+                target: 'runningQuery',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: (context, event) =>
+                    addPredicate(context.query, event.data.predicate),
+                }),
+              },
+              REMOVE_PREDICATE: {
+                target: 'runningQuery',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: (context, event) =>
+                    removePredicate(context.query, event.data.key),
+                }),
+              },
+              TOGGLE_EXCLUDE: {
+                target: 'runningQuery',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: (context, event) =>
+                    toggleExclude(context.query, event.data.key),
+                }),
+              },
+              SET_QUERY: {
+                target: 'runningQuery',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: (_context, event) => ({
+                    predicates: parseQuery(event.data.text),
+                  }),
+                }),
+              },
+              CLEAR_QUERY: {
+                target: 'loadingFromPreviousLibrary',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: () => ({ predicates: [] }),
+                }),
+              },
               SET_TEXT_FILTER: [
                 {
                   cond: notEmpty,
@@ -2757,6 +2923,13 @@ export const libraryMachine = createMachine(
                         }
                         return { tags: Object.keys(activeTags) };
                       },
+                      // Mirror the tag click into the unified query model.
+                      query: (context, event) =>
+                        applyTagClick(
+                          context.query,
+                          event.data.tag,
+                          context.settings.filteringMode
+                        ),
                     }),
                     (context, event) => {
                       // Calculate the new tags for persistence
@@ -2782,6 +2955,11 @@ export const libraryMachine = createMachine(
                       updatePersistedState({
                         ...context,
                         dbQuery: { tags: Object.keys(activeTags) },
+                        query: applyTagClick(
+                          context.query,
+                          event.data.tag,
+                          context.settings.filteringMode
+                        ),
                       });
                       // Invalidate persisted library snapshot to avoid query/library mismatch
                       // Invalidate persisted library snapshot using session store
@@ -2796,6 +2974,41 @@ export const libraryMachine = createMachine(
                   cond: willHaveNoTag,
                 },
               ],
+              ADD_PREDICATE: {
+                target: 'runningQuery',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: (context, event) =>
+                    addPredicate(context.query, event.data.predicate),
+                }),
+              },
+              REMOVE_PREDICATE: {
+                target: 'runningQuery',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: (context, event) =>
+                    removePredicate(context.query, event.data.key),
+                }),
+              },
+              TOGGLE_EXCLUDE: {
+                target: 'runningQuery',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: (context, event) =>
+                    toggleExclude(context.query, event.data.key),
+                }),
+              },
+              SET_QUERY: {
+                target: 'runningQuery',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: (_context, event) => ({
+                    predicates: parseQuery(event.data.text),
+                  }),
+                }),
+              },
+              CLEAR_QUERY: {
+                target: 'loadingFromPreviousLibrary',
+                actions: assign<LibraryState, AnyEventObject>({
+                  query: () => ({ predicates: [] }),
+                }),
+              },
               DELETED_ASSIGNMENT: {
                 // Removing a tag from an image refreshes the current view; it
                 // doesn't navigate. Capture the current libraryLoadId so the

--- a/src/renderer/state.tsx
+++ b/src/renderer/state.tsx
@@ -714,6 +714,57 @@ const getInitialContext = (): LibraryState => {
   };
 };
 
+// Shared query-mutation handlers. Defined once so they can be applied to both
+// the loaded states (loadedFromFS/loadedFromSearch/loadedFromDB) and the
+// loading states (runningQuery/switchingTag/loadingFromDB/loadingFromSearch/
+// changingSearch). Applying them while a query is in flight makes chip edits
+// feel snappy: the assign updates context.query immediately (so the chip UI
+// updates) and targeting runningQuery restarts execution with the latest
+// predicates (latest-wins).
+const queryMutationOn = {
+  ADD_PREDICATE: {
+    target: 'runningQuery',
+    actions: assign<LibraryState, AnyEventObject>({
+      query: (context, event) =>
+        addPredicate(context.query, event.data.predicate),
+    }),
+  },
+  REMOVE_PREDICATE: {
+    target: 'runningQuery',
+    actions: assign<LibraryState, AnyEventObject>({
+      query: (context, event) =>
+        removePredicate(context.query, event.data.key),
+    }),
+  },
+  TOGGLE_EXCLUDE: {
+    target: 'runningQuery',
+    actions: assign<LibraryState, AnyEventObject>({
+      query: (context, event) =>
+        toggleExclude(context.query, event.data.key),
+    }),
+  },
+  SET_PREDICATE_JOIN: {
+    target: 'runningQuery',
+    actions: assign<LibraryState, AnyEventObject>({
+      query: (context, event) =>
+        setPredicateJoin(context.query, event.data.key, event.data.join),
+    }),
+  },
+  SET_QUERY: {
+    target: 'runningQuery',
+    actions: assign<LibraryState, AnyEventObject>({
+      query: (_context, event) => ({
+        predicates: parseQuery(event.data.text),
+      }),
+    }),
+  },
+  CLEAR_QUERY: {
+    // No actions: loadingFromPreviousLibrary's entry restores query/library
+    // from the previous* snapshot (mirrors CLEAR_QUERY_TAG).
+    target: 'loadingFromPreviousLibrary',
+  },
+};
+
 export const libraryMachine = createMachine(
   {
     id: 'library',
@@ -1611,6 +1662,7 @@ export const libraryMachine = createMachine(
                 target: 'loadedFromFS',
               },
             },
+            on: { ...queryMutationOn },
           },
           loadingFromSearch: {
             invoke: {
@@ -1635,6 +1687,7 @@ export const libraryMachine = createMachine(
                 target: 'loadedFromFS',
               },
             },
+            on: { ...queryMutationOn },
           },
           changingSearch: {
             invoke: {
@@ -1659,6 +1712,7 @@ export const libraryMachine = createMachine(
                 target: 'loadedFromFS',
               },
             },
+            on: { ...queryMutationOn },
           },
           switchingTag: {
             invoke: {
@@ -1677,6 +1731,7 @@ export const libraryMachine = createMachine(
                 target: 'loadedFromFS',
               },
             },
+            on: { ...queryMutationOn },
           },
           // Unified query loader. Runs the structured `query` predicate list
           // through a single platform service. New query events (ADD_PREDICATE,
@@ -1696,6 +1751,7 @@ export const libraryMachine = createMachine(
                 target: 'loadedFromFS',
               },
             },
+            on: { ...queryMutationOn },
           },
           loadingFromPersisted: {
             entry: assign<LibraryState, AnyEventObject>({

--- a/src/renderer/state.tsx
+++ b/src/renderer/state.tsx
@@ -193,6 +193,30 @@ const capturePrevious = assign<LibraryState, AnyEventObject>({
   previousInitialFile: (context) => context.initialFile,
 });
 
+// Capture the current view into the previous-state slot ONLY if nothing is
+// stored there yet. The query-mutation handlers use this so the first filter
+// applied from a view (typically FS) snapshots that view — letting a later
+// "removed the last predicate" restore it from memory (loadingFromPreviousLibrary).
+// Subsequent edits (slot already full) leave the snapshot intact.
+const capturePreviousIfEmpty = assign<LibraryState, AnyEventObject>({
+  previousLibrary: (c) =>
+    c.previousLibrary.length > 0 ? c.previousLibrary : c.library,
+  previousCursor: (c) =>
+    c.previousLibrary.length > 0 ? c.previousCursor : c.cursor,
+  previousStateType: (c) =>
+    c.previousLibrary.length > 0 ? c.previousStateType : c.currentStateType,
+  previousTextFilter: (c) =>
+    c.previousLibrary.length > 0 ? c.previousTextFilter : c.textFilter,
+  previousDbQuery: (c) =>
+    c.previousLibrary.length > 0 ? c.previousDbQuery : { ...c.dbQuery },
+  previousQuery: (c) =>
+    c.previousLibrary.length > 0
+      ? c.previousQuery
+      : { predicates: [...c.query.predicates] },
+  previousInitialFile: (c) =>
+    c.previousLibrary.length > 0 ? c.previousInitialFile : c.initialFile,
+});
+
 const setLibraryWithPrevious = assign<LibraryState, AnyEventObject>({
   // Only save previous state if not already saved by an action (check if previousLibrary is empty)
   previousLibrary: (context) =>
@@ -725,24 +749,38 @@ const getInitialContext = (): LibraryState => {
 const queryMutationOn = {
   ADD_PREDICATE: {
     target: 'runningQuery',
-    actions: assign<LibraryState, AnyEventObject>((context, event) => {
-      // EXCLUSIVE mode replaces the entire query with the selected filter,
-      // regardless of predicate type (tag/path/category/description/hash).
-      const q = addPredicateWithMode(
-        context.query,
-        event.data.predicate,
-        context.settings.filteringMode
-      );
-      return { query: q, dbQuery: { tags: tagsFromQuery(q) } };
-    }),
+    actions: [
+      // Snapshot the pre-query (e.g. FS) view so clearing back to empty can
+      // restore it from memory.
+      capturePreviousIfEmpty,
+      assign<LibraryState, AnyEventObject>((context, event) => {
+        // EXCLUSIVE mode replaces the entire query with the selected filter,
+        // regardless of predicate type (tag/path/category/description/hash).
+        const q = addPredicateWithMode(
+          context.query,
+          event.data.predicate,
+          context.settings.filteringMode
+        );
+        return { query: q, dbQuery: { tags: tagsFromQuery(q) } };
+      }),
+    ],
   },
-  REMOVE_PREDICATE: {
-    target: 'runningQuery',
-    actions: assign<LibraryState, AnyEventObject>((context, event) => {
-      const q = removePredicate(context.query, event.data.key);
-      return { query: q, dbQuery: { tags: tagsFromQuery(q) } };
-    }),
-  },
+  REMOVE_PREDICATE: [
+    {
+      // Removing the LAST predicate returns to the previous library (e.g. the
+      // FS view) from memory — mirrors clearing the last tag / the search.
+      target: 'loadingFromPreviousLibrary',
+      cond: (context: LibraryState, event: AnyEventObject) =>
+        removePredicate(context.query, event.data.key).predicates.length === 0,
+    },
+    {
+      target: 'runningQuery',
+      actions: assign<LibraryState, AnyEventObject>((context, event) => {
+        const q = removePredicate(context.query, event.data.key);
+        return { query: q, dbQuery: { tags: tagsFromQuery(q) } };
+      }),
+    },
+  ],
   TOGGLE_EXCLUDE: {
     target: 'runningQuery',
     actions: assign<LibraryState, AnyEventObject>((context, event) => {
@@ -757,13 +795,24 @@ const queryMutationOn = {
       return { query: q, dbQuery: { tags: tagsFromQuery(q) } };
     }),
   },
-  SET_QUERY: {
-    target: 'runningQuery',
-    actions: assign<LibraryState, AnyEventObject>((_context, event) => {
-      const q = { predicates: parseQuery(event.data.text) };
-      return { query: q, dbQuery: { tags: tagsFromQuery(q) } };
-    }),
-  },
+  SET_QUERY: [
+    {
+      // Clearing the text to an empty query returns to the previous library.
+      target: 'loadingFromPreviousLibrary',
+      cond: (_context: LibraryState, event: AnyEventObject) =>
+        parseQuery(event.data.text).length === 0,
+    },
+    {
+      target: 'runningQuery',
+      actions: [
+        capturePreviousIfEmpty,
+        assign<LibraryState, AnyEventObject>((_context, event) => {
+          const q = { predicates: parseQuery(event.data.text) };
+          return { query: q, dbQuery: { tags: tagsFromQuery(q) } };
+        }),
+      ],
+    },
+  ],
   CLEAR_QUERY: {
     // No actions: loadingFromPreviousLibrary's entry restores query/library
     // from the previous* snapshot (mirrors CLEAR_QUERY_TAG).

--- a/src/renderer/state.tsx
+++ b/src/renderer/state.tsx
@@ -18,7 +18,7 @@ import {
 import type { Query } from './query/types';
 import { predicateKey } from './query/types';
 import {
-  addPredicate,
+  addPredicateWithMode,
   removePredicate,
   toggleExclude,
   applyTagClick,
@@ -726,7 +726,13 @@ const queryMutationOn = {
   ADD_PREDICATE: {
     target: 'runningQuery',
     actions: assign<LibraryState, AnyEventObject>((context, event) => {
-      const q = addPredicate(context.query, event.data.predicate);
+      // EXCLUSIVE mode replaces the entire query with the selected filter,
+      // regardless of predicate type (tag/path/category/description/hash).
+      const q = addPredicateWithMode(
+        context.query,
+        event.data.predicate,
+        context.settings.filteringMode
+      );
       return { query: q, dbQuery: { tags: tagsFromQuery(q) } };
     }),
   },

--- a/src/renderer/state.tsx
+++ b/src/renderer/state.tsx
@@ -101,6 +101,9 @@ type LibraryState = {
     loopLength: number;
     loopStartTime: number;
     loopCount: number;
+    // Detected (or 0 = unknown) frame rate of the loaded video, used to drive
+    // single-frame stepping in the controls. See src/renderer/video-frame.ts.
+    frameRate: number;
   };
   // Audio tracks discovered on the currently-loaded <video> element. Reset
   // to [] when the path changes; populated on `loadedmetadata`. The list
@@ -615,6 +618,7 @@ const getInitialContext = (): LibraryState => {
       loopLength: 0,
       loopStartTime: 0,
       loopCount: 0,
+      frameRate: 0,
     },
     settings: {
       order: batched['sortOrder'] as 'asc' | 'desc',
@@ -1167,6 +1171,16 @@ export const libraryMachine = createMachine(
                 return {
                   ...context.videoPlayer,
                   videoLength: event.videoLength,
+                };
+              },
+            }),
+          },
+          SET_VIDEO_FRAME_RATE: {
+            actions: assign<LibraryState, AnyEventObject>({
+              videoPlayer: (context, event) => {
+                return {
+                  ...context.videoPlayer,
+                  frameRate: event.frameRate,
                 };
               },
             }),
@@ -2695,6 +2709,16 @@ export const libraryMachine = createMachine(
                         return {
                           ...context.videoPlayer,
                           videoLength: event.videoLength,
+                        };
+                      },
+                    }),
+                  },
+                  SET_VIDEO_FRAME_RATE: {
+                    actions: assign<LibraryState, AnyEventObject>({
+                      videoPlayer: (context, event) => {
+                        return {
+                          ...context.videoPlayer,
+                          frameRate: event.frameRate,
                         };
                       },
                     }),

--- a/src/renderer/state.tsx
+++ b/src/renderer/state.tsx
@@ -11,7 +11,6 @@ import {
 } from 'settings';
 import {
   invoke, send, on, store, appArgs, capabilities, isElectron,
-  loadMediaFromDB as platformLoadMediaFromDB,
   loadMediaByDescriptionSearch as platformLoadMediaByDescriptionSearch,
   loadMediaByQuery as platformLoadMediaByQuery,
 } from './platform';
@@ -736,7 +735,7 @@ const getInitialContext = (): LibraryState => {
 
 // Shared query-mutation handlers. Defined once so they can be applied to both
 // the loaded states (loadedFromFS/loadedFromDB) and the
-// loading states (runningQuery/switchingTag/loadingFromDB). Applying them while
+// loading states (runningQuery/loadingFromDB). Applying them while
 // a query is in flight makes chip edits
 // feel snappy: the assign updates context.query immediately (so the chip UI
 // updates) and targeting runningQuery restarts execution with the latest
@@ -1696,35 +1695,14 @@ export const libraryMachine = createMachine(
           },
           loadingFromDB: {
             invoke: {
-              src: (context, event) => {
-                console.log('loading from DB', context, event);
-                return platformLoadMediaFromDB(
-                  context.dbQuery.tags,
+              src: (context) =>
+                platformLoadMediaByQuery(
+                  context.query.predicates,
                   context.settings.filteringMode
-                );
-              },
+                ),
               onDone: {
                 target: 'loadedFromDB',
                 actions: ['setLibraryWithPrevious'],
-              },
-              onError: {
-                target: 'loadedFromFS',
-              },
-            },
-            on: { ...queryMutationOn },
-          },
-          switchingTag: {
-            invoke: {
-              src: (context, event) => {
-                console.log('switchingTag', context, event);
-                return platformLoadMediaFromDB(
-                  context.dbQuery.tags,
-                  context.settings.filteringMode
-                );
-              },
-              onDone: {
-                target: 'loadedFromDB',
-                actions: ['setLibrary'],
               },
               onError: {
                 target: 'loadedFromFS',
@@ -2421,11 +2399,11 @@ export const libraryMachine = createMachine(
                     );
                     return remaining.length > 0;
                   },
-                  // Target switchingTag (which uses setLibrary, not
+                  // Target runningQuery (which uses setLibrary, not
                   // setLibraryWithPrevious) so the original entry-mode
                   // previous (e.g. FS → DB) is preserved across within-DB
                   // tag tweaks. Symmetric with SET_QUERY_TAG.
-                  target: 'switchingTag',
+                  target: 'runningQuery',
                   actions: [
                     assign<LibraryState, AnyEventObject>({
                       dbQuery: (context, event) => ({
@@ -2544,7 +2522,7 @@ export const libraryMachine = createMachine(
               },
               SET_QUERY_TAG: [
                 {
-                  target: 'switchingTag',
+                  target: 'runningQuery',
                   cond: willHaveTag,
                   actions: [
                     assign<LibraryState, AnyEventObject>({
@@ -2639,7 +2617,7 @@ export const libraryMachine = createMachine(
                 // doesn't navigate. Capture the current libraryLoadId so the
                 // list can recognize the upcoming setLibrary as an in-place
                 // refresh and preserve scroll instead of jumping to top.
-                target: 'switchingTag',
+                target: 'runningQuery',
                 actions: [
                   assign<LibraryState, AnyEventObject>({
                     preserveScrollFromLoadId: (context) => context.libraryLoadId,
@@ -2648,7 +2626,7 @@ export const libraryMachine = createMachine(
                 ],
               },
               SORTED_WEIGHTS: {
-                target: 'switchingTag',
+                target: 'runningQuery',
                 actions: () => console.log('sorting weights'),
               },
             },

--- a/src/renderer/state.tsx
+++ b/src/renderer/state.tsx
@@ -11,7 +11,6 @@ import {
 } from 'settings';
 import {
   invoke, send, on, store, appArgs, capabilities, isElectron,
-  loadMediaByDescriptionSearch as platformLoadMediaByDescriptionSearch,
   loadMediaByQuery as platformLoadMediaByQuery,
 } from './platform';
 import type { Query } from './query/types';

--- a/src/renderer/state.tsx
+++ b/src/renderer/state.tsx
@@ -104,6 +104,8 @@ type LibraryState = {
     // Detected (or 0 = unknown) frame rate of the loaded video, used to drive
     // single-frame stepping in the controls. See src/renderer/video-frame.ts.
     frameRate: number;
+    // Playback speed multiplier (1 = normal), applied to the media element.
+    playbackRate: number;
   };
   // Audio tracks discovered on the currently-loaded <video> element. Reset
   // to [] when the path changes; populated on `loadedmetadata`. The list
@@ -619,6 +621,7 @@ const getInitialContext = (): LibraryState => {
       loopStartTime: 0,
       loopCount: 0,
       frameRate: 0,
+      playbackRate: 1,
     },
     settings: {
       order: batched['sortOrder'] as 'asc' | 'desc',
@@ -1181,6 +1184,16 @@ export const libraryMachine = createMachine(
                 return {
                   ...context.videoPlayer,
                   frameRate: event.frameRate,
+                };
+              },
+            }),
+          },
+          SET_PLAYBACK_RATE: {
+            actions: assign<LibraryState, AnyEventObject>({
+              videoPlayer: (context, event) => {
+                return {
+                  ...context.videoPlayer,
+                  playbackRate: event.playbackRate,
                 };
               },
             }),
@@ -2719,6 +2732,16 @@ export const libraryMachine = createMachine(
                         return {
                           ...context.videoPlayer,
                           frameRate: event.frameRate,
+                        };
+                      },
+                    }),
+                  },
+                  SET_PLAYBACK_RATE: {
+                    actions: assign<LibraryState, AnyEventObject>({
+                      videoPlayer: (context, event) => {
+                        return {
+                          ...context.videoPlayer,
+                          playbackRate: event.playbackRate,
                         };
                       },
                     }),

--- a/src/renderer/state.tsx
+++ b/src/renderer/state.tsx
@@ -34,6 +34,7 @@ import {
   flushSession,
   hasPersistedLibrary as checkHasPersistedLibrary,
   hasPersistedTags as checkHasPersistedTags,
+  hasPersistedQuery as checkHasPersistedQuery,
 } from './hooks/useSessionStore';
 // Job management removed - now handled by external job runner service
 
@@ -441,8 +442,13 @@ const hasPersistedLibrary = (_context: LibraryState): boolean => {
   return checkHasPersistedLibrary();
 };
 
-const hasPersistedTags = (_context: LibraryState): boolean => {
-  return checkHasPersistedTags();
+// Boot/restore routing guard: true when there is ANY persisted filter to
+// restore — legacy tags OR a unified query holding non-tag predicates (path /
+// category / description / hash). Routing on tags alone misclassified a
+// path-only query as "no filter", sending it to the FS view whose entry then
+// wiped the persisted predicate.
+const hasPersistedFilter = (_context: LibraryState): boolean => {
+  return checkHasPersistedTags() || checkHasPersistedQuery();
 };
 
 const willHaveTag = (context: LibraryState, event: AnyEventObject) => {
@@ -1460,7 +1466,7 @@ export const libraryMachine = createMachine(
               },
             }),
             always: [
-              { target: 'loadingFromDB', cond: hasPersistedTags },
+              { target: 'loadingFromDB', cond: hasPersistedFilter },
               { target: 'selectingDirectory' },
             ],
           },
@@ -1802,7 +1808,7 @@ export const libraryMachine = createMachine(
               libraryLoadId: () => uniqueId(),
             }),
             always: [
-              { target: 'loadedFromDB', cond: hasPersistedTags },
+              { target: 'loadedFromDB', cond: hasPersistedFilter },
               { target: 'loadedFromFS' },
             ],
           },

--- a/src/renderer/video-frame.ts
+++ b/src/renderer/video-frame.ts
@@ -69,6 +69,36 @@ export function frameStep(
   return Math.min(Math.max(next, 0), maxTime);
 }
 
+// Which time the scrubber should display: the live drag position while
+// dragging (instant, cursor-locked), otherwise the actual decoded time. This
+// decouples the thumb/label from the seek round-trip, which is the main cause
+// of laggy-feeling scrubbing.
+export function selectDisplayTime(
+  isDragging: boolean,
+  dragTime: number | null,
+  actualVideoTime: number
+): number {
+  if (isDragging && dragTime != null) return dragTime;
+  return actualVideoTime;
+}
+
+// Coalesced seeking decision: returns the time to seek to NOW, or null to wait.
+// While a seek is in flight we issue no new seek (prevents a backlog that makes
+// the picture lag behind the cursor); the `seeked` handler re-checks and seeks
+// to the latest pending target once the element is free. This keeps exactly one
+// seek in flight and always converges to `pending`.
+export function coalescedSeekTarget(
+  pending: number | null,
+  isSeeking: boolean,
+  currentTime: number,
+  tolerance = 0.001
+): number | null {
+  if (pending == null) return null;
+  if (isSeeking) return null;
+  if (Math.abs(pending - currentTime) <= tolerance) return null;
+  return pending;
+}
+
 // Map a horizontal pixel offset on the progress bar to a fractional time in
 // seconds. The clamp keeps the result within [0, duration]. Crucially this
 // does NOT round to whole seconds — that rounding was the original cause of

--- a/src/renderer/video-frame.ts
+++ b/src/renderer/video-frame.ts
@@ -99,6 +99,17 @@ export function coalescedSeekTarget(
   return pending;
 }
 
+// Seek a fixed number of seconds from the current time (negative to rewind),
+// clamped to [0, duration]. Returns 0 when the duration is unknown.
+export function seekBy(
+  currentTime: number,
+  deltaSeconds: number,
+  duration: number
+): number {
+  if (!(duration > 0)) return 0;
+  return Math.min(Math.max(currentTime + deltaSeconds, 0), duration);
+}
+
 // Map a horizontal pixel offset on the progress bar to a fractional time in
 // seconds. The clamp keeps the result within [0, duration]. Crucially this
 // does NOT round to whole seconds — that rounding was the original cause of

--- a/src/renderer/video-frame.ts
+++ b/src/renderer/video-frame.ts
@@ -1,0 +1,84 @@
+// Pure helpers for frame-accurate video scrubbing.
+//
+// These are deliberately free of any DOM / React dependency so they can be
+// unit-tested in isolation (see src/__tests__/video-frame.test.ts). The
+// `Video` component feeds raw `requestVideoFrameCallback` mediaTime samples
+// into `estimateFrameRate`; `VideoControls` uses `frameStep` and `pixelToTime`
+// to compute fractional seek targets.
+
+// Used whenever the real frame rate is unknown (rVFC unavailable, variable
+// frame rate with no stable estimate, or detection hasn't completed yet).
+export const DEFAULT_FPS = 30;
+
+// Common broadcast/film frame rates a noisy estimate is snapped toward.
+const COMMON_RATES = [23.976, 24, 25, 29.97, 30, 50, 59.94, 60];
+
+// Snap a raw fps estimate to the nearest common rate when it is within
+// `tolerance` (relative, default 2%); otherwise return the raw estimate
+// rounded to 3 decimals. Invalid input yields 0 ("unknown").
+export function snapFrameRate(raw: number, tolerance = 0.02): number {
+  if (!isFinite(raw) || raw <= 0) return 0;
+  let best = raw;
+  let bestErr = Infinity;
+  for (const r of COMMON_RATES) {
+    const err = Math.abs(raw - r) / r;
+    if (err < bestErr) {
+      bestErr = err;
+      best = r;
+    }
+  }
+  if (bestErr <= tolerance) return best;
+  return Math.round(raw * 1000) / 1000;
+}
+
+// Estimate fps from a sequence of mediaTime samples (seconds) reported by
+// requestVideoFrameCallback. Backward deltas (a loop reset on a short looping
+// video) and absurd gaps (a pause/seek of >= 1s) are discarded. Returns 0 when
+// there aren't enough usable deltas to make a stable estimate.
+export function estimateFrameRate(mediaTimes: number[]): number {
+  if (!Array.isArray(mediaTimes) || mediaTimes.length < 3) return 0;
+  const deltas: number[] = [];
+  for (let i = 1; i < mediaTimes.length; i++) {
+    const d = mediaTimes[i] - mediaTimes[i - 1];
+    if (d > 0 && d < 1) deltas.push(d);
+  }
+  if (deltas.length < 2) return 0;
+  deltas.sort((a, b) => a - b);
+  const mid = Math.floor(deltas.length / 2);
+  const median =
+    deltas.length % 2 === 0 ? (deltas[mid - 1] + deltas[mid]) / 2 : deltas[mid];
+  if (median <= 0) return 0;
+  return snapFrameRate(1 / median);
+}
+
+// Compute the seek target one frame away from `currentTime` in `direction`
+// (+1 next, -1 previous). Falls back to DEFAULT_FPS when `frameRate` is unknown
+// or invalid. Clamped to [0, duration - halfFrame] so we never land exactly on
+// or past the end. Returns 0 when duration is unknown (<= 0).
+export function frameStep(
+  currentTime: number,
+  frameRate: number,
+  direction: 1 | -1,
+  duration: number
+): number {
+  const fps = frameRate > 0 && isFinite(frameRate) ? frameRate : DEFAULT_FPS;
+  const step = 1 / fps;
+  if (!(duration > 0)) return 0;
+  const next = currentTime + direction * step;
+  const maxTime = Math.max(0, duration - step / 2);
+  return Math.min(Math.max(next, 0), maxTime);
+}
+
+// Map a horizontal pixel offset on the progress bar to a fractional time in
+// seconds. The clamp keeps the result within [0, duration]. Crucially this
+// does NOT round to whole seconds — that rounding was the original cause of
+// "second-by-second only" scrubbing.
+export function pixelToTime(
+  offsetX: number,
+  width: number,
+  duration: number
+): number {
+  if (width <= 0 || duration <= 0) return 0;
+  const clamped = Math.max(0, Math.min(offsetX, width));
+  return (clamped / width) * duration;
+}


### PR DESCRIPTION
## Summary

Replaces the old, mutually-exclusive tag-filter / text-search split in the taxonomy panel with a single **composable, structured query** — and makes it fast on the real library.

### Query model & UI
- One query = a flat list of typed predicates (`tag` / `category` / `path` / `description` / `hash`), each with include/exclude and a per-predicate **AND/OR join** (faceted: all-AND required + OR-group), combined under the existing AND/OR/**EXCLUSIVE** mode.
- `QueryInput` is now a **chip editor**: chips are the live query; typing drives type-ahead. The first chip is the base (no join badge) so the query reads linearly; EXCLUSIVE replaces the query for any selected filter.
- The two old search boxes are merged into one; type-ahead surfaces **Tags → Categories → Paths → Suggested → Description → Hash**, with substring "+" rows for free-text fields.
- Removing the last predicate restores the previous (in-memory) library, like clearing the last tag used to.

### Single source of truth & one engine
- `query` is authoritative; the legacy `dbQuery.tags` is a derived projection (fixes the tags-list / command-palette desync).
- Collapsed the state machine to **fs vs db-query**; `loadMediaByQuery` is the sole loader (removed the separate tag and description-search execution paths). The Go media-server engine is kept at parity.

### Performance (validated against the live 9.8GB dream-x.sqlite — 1.96M media / 16.4M tags)
- Tag, category, and OR-set queries **drive from the indexed `media_tag_by_category` lookup** instead of scanning `media` (EXPLAIN-confirmed: index search, no scan, no temp-btree sort).
  - Single tag filtering: media-scan **2384ms → 65ms**.
  - Category (Characters): **4833ms → 128ms**; Artists **4781ms → 251ms**.
- `description` is filtered but no longer selected into rows; ordering is done in the renderer (no SQL `ORDER BY`).
- One **shared tag-search worker/index**, warmed at startup, used by both the taxonomy sidebar and the command palette.

### Command palette
- The filter-pill row is replaced by the same chip query input + in-place type-ahead (an alternative entry point to the sidebar); curated (non-Suggested) tags are prioritized; search input is focused on open; hotkeys are disabled while typing.

### Safety / fixes
- Block toggling the only include predicate to exclude (an all-exclude query scans the whole DB).
- Truncate long path/value matches; fix a dev-only web-worker React-Refresh `importScripts` crash.

## Testing
- **294 Jest tests** (renderer, incl. parser/reducer/SQL-builder + state contract) and **all Go tests** pass; `npm run build` exit 0; lint clean.
- New SQL behavior validated with `EXPLAIN QUERY PLAN` + timings against the real database.

## Note for review
The deep state-machine + UI changes were verified via the test suite and DB-level `EXPLAIN`/timings, but not by driving the Electron UI headlessly — a manual pass of tag/category/AND/OR browsing, chip editing, and the command-palette search is worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)